### PR TITLE
Update copy helper to avoid visible textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,8 +500,22 @@ document.getElementById("export-json").onclick = () => {
 
 function copyText(text) {
   if (!text) return;
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch(() => legacyCopy(text));
+  } else {
+    legacyCopy(text);
+  }
+}
+
+function legacyCopy(text) {
   const temp = document.createElement("textarea");
   temp.value = text;
+  temp.setAttribute("readonly", "");
+  temp.style.position = "fixed";
+  temp.style.opacity = "0";
+  temp.style.pointerEvents = "none";
+  temp.style.left = "-9999px";
+  temp.style.top = "0";
   document.body.appendChild(temp);
   temp.select();
   document.execCommand("copy");


### PR DESCRIPTION
## Summary
- use the asynchronous Clipboard API when available to copy generated text
- hide the fallback textarea used for legacy copy support so it does not appear on screen

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690103db1488832c951acc3ad5ebb220