### PR TITLE
Stop including text payload in shared depot notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,9 +538,7 @@
       if (navigator.canShare && navigator.canShare({ files: [fileForShare] })) {
         try {
           await navigator.share({
-            files: [fileForShare],
-            title: "Depot notes",
-            text: "Latest depot notes export"
+            files: [fileForShare]
           });
           statusBar.textContent = "Notes shared.";
           return;


### PR DESCRIPTION
## Summary
- remove the extra title/text fields when sharing depot notes so iOS saves only the JSON file

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e18968dc832c8d3e1308fefb8020)