### PR TITLE
fix(worker): restore classic worker startup

### DIFF
--- a/public/transcribe-worker.js
+++ b/public/transcribe-worker.js
@@ -1,19 +1,23 @@
-/* Classic (non-module) worker for widest browser support. 
-   Replace internals later with your STT pipeline if needed. */
+/* Classic Web Worker — keeps out of your UI and Cloudflare logic.
+   It does not touch the mic (that’s main thread by spec). Replace internals later if needed. */
 
-self.postMessage({ type: 'ready' });
+self.postMessage({ type:'ready' });
 
-self.addEventListener('message', (e) => {
-  const { type } = e.data || {};
-  if (type === 'init') {
-    self.postMessage({ type: 'log', payload: 'Worker initialised' });
+self.addEventListener('message', (e)=>{
+  const { type, payload } = e.data || {};
+  if(type === 'init'){
+    self.postMessage({ type:'log', payload:'Worker initialised' });
   }
-  if (type === 'start') {
-    // In a real pipeline you’d connect to WebAudio/WASM/stream here.
-    // We can’t access mic from worker; main thread handles audio.
+  if(type === 'start'){
+    // Hook your audio streaming / STT pipeline via main thread -> worker messages, if desired.
     self.postMessage({
-      type: 'error',
-      payload: 'Worker started: waiting for main-thread audio; using fallback if provided.'
+      type:'error',
+      payload:'Worker is running. Provide audio frames or use main-thread SpeechRecognition fallback.'
     });
+  }
+  if(type === 'append-text'){
+    // Optional: you can stream chunks here and have worker coalesce them.
+    self._buf = (self._buf || '') + (payload || '');
+    self.postMessage({ type:'transcript', payload:self._buf });
   }
 });


### PR DESCRIPTION
## Summary
- simplify app worker bootstrapping and remove base-path helpers
- load a classic worker via ESM-safe URL resolution with fallback speech recognition
- extend worker stub to report readiness, errors, and optional transcript accumulation

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69149b325808832ca9ee5f49bc119e9b)