### PR TITLE
feat(structurer): improve depot note routing and summaries

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -139,30 +139,34 @@ const HINTS_DEFAULT = {
   "smart thermostat": "New boiler and controls",
   "controller": "New boiler and controls",
   "control": "New boiler and controls",
+  "magnetic filter": "New boiler and controls",
+  "filter": "New boiler and controls",
   "pump": "New boiler and controls",
   "valve": "New boiler and controls",
   "motorised valve": "New boiler and controls",
-  "filter": "New boiler and controls",
-  "magnetic filter": "New boiler and controls",
 
   // pipework
   "condensate": "Pipe work",
   "condensate pump": "Pipe work",
   "condensate upgrade": "Pipe work",
-  "pipe": "Pipe work",
   "pipework": "Pipe work",
+  "pipe work": "Pipe work",
+  "pipe": "Pipe work",
   "gas run": "Pipe work",
   "gas pipe": "Pipe work",
+  "gas supply": "Pipe work",
+  "increase gas": "Pipe work",
+  "increasing the gas": "Pipe work",
 
   // flue
-  "reuse flue": "Flue",
-  "new flue": "Flue",
-  "balanced flue": "Flue",
-  "vertical flue": "Flue",
-  "rear flue": "Flue",
   "plume kit": "Flue",
   "terminal": "Flue",
   "turret": "Flue",
+  "rear flue": "Flue",
+  "side flue": "Flue",
+  "vertical flue": "Flue",
+  "direct rear": "Flue",
+  "offset": "Flue",
 
   // heights
   "ladders": "Working at heights",
@@ -204,19 +208,25 @@ const HINTS_DEFAULT = {
 function norm(s){ return String(s || "").trim(); }
 function lc(s){ return norm(s).toLowerCase(); }
 function endsSemi(s){ return s.endsWith(";") ? s : (s + ";"); }
+function dedupeWhitespace(s){ return norm(s).replace(/\s+/g," "); }
 
 function splitIntoLines(text){
-  // Split on newlines or sentence ends; keep it simple and fast
   const raw = String(text || "")
     .replace(/\r/g, "")
     .split(/\n+/)
-    .flatMap(line => line.split(/(?<=[.?!])\s+(?=[A-Z])/)); // sentences to lines
-  // Trim & drop empties
+    .flatMap(line => line.split(/(?<=[.?!])\s+(?=[A-Z])/));
   return raw.map(s => s.trim()).filter(Boolean);
 }
 
+function normaliseForRouting(s){
+  let t = lc(s);
+  t = t.replace(/\bcombini\b/g, "combi"); // ASR typo
+  return t;
+}
+
 function routeLine(line, hints){
-  const l = lc(line);
+  const l = normaliseForRouting(line);
+
   // explicit section headers like "Flue:" or "Pipe work - ..."
   for (const name of SECTION_NAMES){
     const rx = new RegExp(`^\\s*${name.replace(/[.*+?^${}()|[\\]\\]/g,"\\$&")}\\s*[:\\-]`, "i");
@@ -226,15 +236,28 @@ function routeLine(line, hints){
   for (const [kw, sec] of Object.entries(hints)){
     if (l.includes(kw)) return sec;
   }
-  return ""; // unclassified (will drop unless forceStructured)
+  return ""; // unclassified
 }
 
-// Merge helpers to fold notes into target sections
 function appendSection(bucket, name, ptAdd, nlAdd=""){
   const b = bucket.get(name) || { section: name, plainText: "", naturalLanguage: "" };
   if (ptAdd) b.plainText = (b.plainText ? b.plainText + " " : "") + endsSemi(ptAdd.trim());
   if (nlAdd) b.naturalLanguage = (b.naturalLanguage ? b.naturalLanguage + " " : "") + nlAdd.trim();
   bucket.set(name, b);
+}
+
+function summariseFlue(allText){
+  const t = lc(allText);
+  const side = /\bside flue\b/.test(t) || /\bturret to the side flue\b/.test(t);
+  const rear = /\brear flue\b/.test(t) || /\bturret rear flue\b/.test(t) || /\bdirect rear\b/.test(t);
+  const vertical = /\bvertical flue\b/.test(t);
+  let bits = [];
+  if (side) bits.push("side/offset turret");
+  if (rear) bits.push("rear/turret");
+  if (vertical) bits.push("vertical");
+  if (/\bplume kit\b/.test(t)) bits.push("plume kit");
+  if (!bits.length && /\bflue\b/.test(t)) bits.push("flue changes");
+  return bits.length ? `Flue: ${bits.join(", ")}.` : "";
 }
 
 function structureDepotNotes(input, cfg = {}){
@@ -243,7 +266,7 @@ function structureDepotNotes(input, cfg = {}){
   const forceStructured = !!cfg.forceStructured;
 
   const lines = splitIntoLines(input);
-  const bucket = new Map(); // name -> { section, plainText, naturalLanguage }
+  const bucket = new Map();
 
   // 1) Route each line
   for (const line of lines){
@@ -252,87 +275,113 @@ function structureDepotNotes(input, cfg = {}){
     appendSection(bucket, target, line);
   }
 
-  // 2) Post-rules (folding/normalisation)
-  // 2a) Controls: gather any controls keywords that may have landed elsewhere
+  // 2) Post-rules (merges/normalisation)
+  // Controls: ensure Hive/filter land in controls
   for (const [name, obj] of [...bucket]) {
     if (name === "New boiler and controls") continue;
     const l = lc(obj.plainText + " " + obj.naturalLanguage);
-    if (/\b(hive|smart control|smart thermostat|controller|control|pump|valve|motorised valve|magnetic filter|filter)\b/i.test(l)){
+    if (/\b(hive|smart control|smart thermostat|controller|control|magnetic filter|filter|pump|valve|motorised valve)\b/.test(l)){
       appendSection(bucket, "New boiler and controls", obj.plainText, obj.naturalLanguage);
       bucket.delete(name);
     }
   }
-  // 2b) Pipework catch-all
+
+  // Pipe work: condensate / pipe / gas supply
   for (const [name, obj] of [...bucket]) {
     if (name === "Pipe work") continue;
     const l = lc(obj.plainText + " " + obj.naturalLanguage);
-    if (/\b(condensate|condensate pump|pipework|pipe|gas run|gas pipe)\b/i.test(l)){
+    if (/\b(condensate|condensate pump|pipework|pipe|gas run|gas pipe|gas supply|increase gas|increasing the gas)\b/.test(l)){
       appendSection(bucket, "Pipe work", obj.plainText, obj.naturalLanguage);
       bucket.delete(name);
     }
   }
-  // 2c) Parking → Restrictions to work (merge)
+
+  // Restrictions to work
   for (const [name, obj] of [...bucket]) {
     if (name === "Restrictions to work") continue;
     const l = lc(obj.plainText + " " + obj.naturalLanguage);
-    if (/\b(parking|permit|no parking|double yellow|access)\b/i.test(l)){
+    if (/\b(parking|permit|no parking|double yellow|access)\b/.test(l)){
       appendSection(bucket, "Restrictions to work", obj.plainText, obj.naturalLanguage);
       bucket.delete(name);
     }
   }
-  // 2d) Planning/listed → Office notes
+
+  // Office notes
   for (const [name, obj] of [...bucket]) {
     if (name === "Office notes") continue;
     const l = lc(obj.plainText + " " + obj.naturalLanguage);
-    if (/\b(planning permission|listed building|conservation area|needs permission)\b/i.test(l)){
+    if (/\b(planning permission|listed building|conservation area|needs permission)\b/.test(l)){
       appendSection(bucket, "Office notes", obj.plainText, obj.naturalLanguage);
       bucket.delete(name);
     }
   }
-  // 2e) Double-handed → Components that require assistance
+
+  // Components that require assistance
   for (const [name, obj] of [...bucket]) {
     if (name === "Components that require assistance") continue;
     const l = lc(obj.plainText + " " + obj.naturalLanguage);
-    if (/\b(double handed|double-hand|2 ?man|two (man|engineers)|2 engineers)\b/i.test(l)){
+    if (/\b(double handed|double-hand|2 ?man|two (man|engineers)|2 engineers)\b/.test(l)){
       appendSection(bucket, "Components that require assistance", obj.plainText, obj.naturalLanguage);
       bucket.delete(name);
     }
   }
-  // 2f) Power flush → add Disruption flag/note
-  let hasFlush = false;
-  for (const [_, obj] of bucket) {
-    if (/\b(power ?flush)\b/i.test(lc(obj.plainText + " " + obj.naturalLanguage))) { hasFlush = true; break; }
-  }
-  if (hasFlush) {
-    appendSection(bucket, "Disruption",
-      "✅ Power flush to be carried out | Allow extra time and clear access;",
-      "A power flush will be carried out, so extra time and access are needed."
-    );
+
+  // Disruption (single entry only if power flush anywhere)
+  const allText = lines.join(" ");
+  if (/\bpower ?flush\b/i.test(allText)) {
+    bucket.set("Disruption", {
+      section: "Disruption",
+      plainText: "✅ Power flush to be carried out | Allow extra time and clear access;",
+      naturalLanguage: "A power flush will be carried out, so extra time and access are needed."
+    });
   }
 
-  // 3) Build ordered list, ensure semicolons, remove empties
+  // Flue summary: if any flue/turret/plume keywords present, add a clean NL line
+  if (/\b(flue|turret|plume|terminal|rear flue|side flue|vertical flue|direct rear)\b/i.test(allText)) {
+    const summary = summariseFlue(allText);
+    if (summary) {
+      const existing = bucket.get("Flue") || { section: "Flue", plainText: "", naturalLanguage: "" };
+      existing.naturalLanguage = dedupeWhitespace((existing.naturalLanguage ? existing.naturalLanguage + " " : "") + summary);
+      bucket.set("Flue", existing);
+    }
+  }
+
+  // 3) Build ordered list, ensure semicolons, remove empties & duplicates
   let sections = [...bucket.values()]
     .map(s => ({
       section: s.section,
-      plainText: norm(s.plainText),
+      plainText: norm(s.plainText).split(/\s*;\s*/).filter(Boolean).map(x => endsSemi(x)).join(" "),
       naturalLanguage: norm(s.naturalLanguage)
     }))
     .filter(s => s.plainText || s.naturalLanguage);
 
+  // Coalesce duplicates by section name (defensive)
+  const byName = new Map();
+  for (const s of sections) {
+    const key = s.section;
+    if (!byName.has(key)) byName.set(key, { section:key, plainText:"", naturalLanguage:"" });
+    const acc = byName.get(key);
+    acc.plainText = norm((acc.plainText ? acc.plainText + " " : "") + s.plainText);
+    acc.naturalLanguage = norm((acc.naturalLanguage ? acc.naturalLanguage + " " : "") + s.naturalLanguage);
+  }
+  sections = [...byName.values()];
   sections.sort((a,b) => (SECTION_ORDER[a.section]||999) - (SECTION_ORDER[b.section]||999));
 
-  // 4) If forceStructured but nothing matched, emit empty skeleton in expected order
+  // 4) Skeleton when forced
   if (forceStructured && sections.length === 0) {
     sections = expected.map(name => ({ section: name, plainText: "", naturalLanguage: "" }));
   }
 
-  // Customer summary + basic questions
-  const customerSummary = String(input || "").trim().split(/\n/)[0]?.slice(0,180) || "";
+  // Customer summary: first substantive line (skip “test”, “let’s give this a test” etc.)
+  const firstGood = splitIntoLines(input).find(l => !/^test\b/i.test(l) && !/^let['’]s give this a test/i.test(l)) || "";
+  const customerSummary = firstGood.slice(0,180);
+
+  // Minimal question stubs
   const missingInfo = [];
-  if (!/\b(hive|smart control|controller|smart thermostat)\b/i.test(lc(input))) {
+  if (!/\b(hive|smart control|controller|smart thermostat)\b/i.test(allText)) {
     missingInfo.push({ target: "customer", question: "Do you want a smart control (e.g., Hive)?" });
   }
-  if (!/\b(condensate)\b/i.test(lc(input))) {
+  if (!/\b(condensate)\b/i.test(allText)) {
     missingInfo.push({ target: "engineer", question: "Confirm condensate route and termination." });
   }
 


### PR DESCRIPTION
## Summary
- route controls, pipe work, and flue notes to the correct sections with typo normalisation
- ensure Disruption only includes one power-flush entry and add flue natural-language summaries
- pick the first substantive line for the customer summary and coalesce duplicate section outputs

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914e0afe22c832cbcb94654a40da901)