### PR TITLE
chore: align default routing overrides with config

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -40,7 +40,11 @@ function defaultRoutingConfig() {
     ],
     phrase_overrides: {
       "two engineers": "Components that require assistance",
-      "double handed": "Components that require assistance"
+      "double handed": "Components that require assistance",
+      "planning permission": "Office notes",
+      "listed building": "Office notes",
+      "conservation area": "Office notes",
+      "permit required": "Restrictions to work"
     },
     intents: {
       controls: [


### PR DESCRIPTION
## Summary
- align the worker's default routing phrase overrides with the external routing.json so fallback behaviour matches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914ed5abf84832cadab76ecfd154782)