### PR TITLE
Allow overriding worker endpoint from settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,11 +329,18 @@
   <input id="importAudioInput" type="file" accept="audio/*" style="display:none;">
 
   <script type="module">
-    import { loadChecklistConfig, loadDepotSchema, loadChecklistState, saveChecklistState } from "./src/app/state.js";
+    import {
+      loadChecklistConfig,
+      loadDepotSchema,
+      loadChecklistState,
+      saveChecklistState,
+      loadWorkerUrl,
+      DEFAULT_WORKER_URL as STATE_DEFAULT_WORKER_URL
+    } from "./src/app/state.js";
     import { initDepotRenderers, refreshDepotNotesFromChecklist } from "./src/app/renderDepot.js";
 
-    // hard-code your worker so it isn't visible
-    const WORKER_URL = "https://survey-brain-api.martinbibb.workers.dev";
+    // Worker endpoint can be overridden from the settings page
+    const WORKER_URL = loadWorkerUrl(STATE_DEFAULT_WORKER_URL);
 
     const sendTextBtn = document.getElementById('sendTextBtn');
     const transcriptInput = document.getElementById('transcriptInput');

--- a/settings.html
+++ b/settings.html
@@ -61,6 +61,15 @@
       color: #0f172a;
       resize: vertical;
     }
+    input[type="url"] {
+      width: 100%;
+      border-radius: 12px;
+      border: 1px solid #cbd5e1;
+      padding: 10px 12px;
+      font-size: 0.8rem;
+      background: #f8fafc;
+      color: #0f172a;
+    }
     textarea#settings-schema-json {
       min-height: 180px;
     }
@@ -116,6 +125,15 @@
       <div class="btn-row">
         <button id="btn-save-schema">Save (this device)</button>
         <button id="btn-reset-schema" class="secondary">Reset to defaults</button>
+      </div>
+    </section>
+    <section>
+      <h2>Worker endpoint</h2>
+      <p>Override the Cloudflare Worker URL used for Pro transcription. Leave blank to fall back to the default.</p>
+      <input id="settings-worker-url" type="url" placeholder="https://example.workers.dev" spellcheck="false" />
+      <div class="btn-row">
+        <button id="btn-save-worker">Save (this device)</button>
+        <button id="btn-reset-worker" class="secondary">Reset to default</button>
       </div>
     </section>
   </main>

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -4,6 +4,9 @@ import defaultDepotSchema from "../../data/depot.output.schema.json" assert { ty
 const LS_CHECKLIST_CONFIG_KEY = "depot-checklist-config";
 const LS_SCHEMA_KEY = "depot-output-schema";
 const LS_CHECKLIST_STATE_KEY = "depot-checklist-state";
+const LS_WORKER_URL_KEY = "depot-worker-url";
+
+export const DEFAULT_WORKER_URL = "https://survey-brain-api.martinbibb.workers.dev";
 
 function deepClone(value) {
   if (value === undefined || value === null) {
@@ -62,7 +65,32 @@ export function saveChecklistState(state) {
   saveJson(LS_CHECKLIST_STATE_KEY, state || {});
 }
 
+export function loadWorkerUrl(fallback = DEFAULT_WORKER_URL) {
+  try {
+    const raw = localStorage.getItem(LS_WORKER_URL_KEY);
+    if (!raw) return fallback;
+    const trimmed = raw.trim();
+    return trimmed || fallback;
+  } catch (_) {
+    return fallback;
+  }
+}
+
+export function saveWorkerUrl(url) {
+  try {
+    const trimmed = (url || "").trim();
+    if (!trimmed) {
+      localStorage.removeItem(LS_WORKER_URL_KEY);
+      return;
+    }
+    localStorage.setItem(LS_WORKER_URL_KEY, trimmed);
+  } catch (_) {
+    // ignore storage errors
+  }
+}
+
 export const DEFAULT_CHECKLIST_CONFIG = defaultChecklistConfig;
 export const DEFAULT_DEPOT_SCHEMA = defaultDepotSchema;
 export const CHECKLIST_CONFIG_STORAGE_KEY = LS_CHECKLIST_CONFIG_KEY;
 export const DEPOT_SCHEMA_STORAGE_KEY = LS_SCHEMA_KEY;
+export const WORKER_URL_STORAGE_KEY = LS_WORKER_URL_KEY;

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -4,7 +4,10 @@ import {
   DEFAULT_CHECKLIST_CONFIG,
   DEFAULT_DEPOT_SCHEMA,
   CHECKLIST_CONFIG_STORAGE_KEY,
-  DEPOT_SCHEMA_STORAGE_KEY
+  DEPOT_SCHEMA_STORAGE_KEY,
+  loadWorkerUrl,
+  saveWorkerUrl,
+  DEFAULT_WORKER_URL
 } from "../app/state.js";
 
 function saveJson(key, value) {
@@ -18,6 +21,7 @@ function saveJson(key, value) {
 export function initSettingsPage() {
   const checklistArea = document.getElementById("settings-checklist-json");
   const schemaArea = document.getElementById("settings-schema-json");
+  const workerInput = document.getElementById("settings-worker-url");
 
   if (!checklistArea || !schemaArea) {
     console.warn("Settings areas missing from DOM");
@@ -26,9 +30,13 @@ export function initSettingsPage() {
 
   const checklistCurrent = loadChecklistConfig();
   const schemaCurrent = loadDepotSchema();
+  const workerCurrent = loadWorkerUrl(DEFAULT_WORKER_URL);
 
   checklistArea.value = JSON.stringify(checklistCurrent, null, 2);
   schemaArea.value = JSON.stringify(schemaCurrent, null, 2);
+  if (workerInput) {
+    workerInput.value = workerCurrent || "";
+  }
 
   document.getElementById("btn-save-checklist")?.addEventListener("click", () => {
     try {
@@ -59,6 +67,34 @@ export function initSettingsPage() {
     schemaArea.value = JSON.stringify(DEFAULT_DEPOT_SCHEMA, null, 2);
     saveJson(DEPOT_SCHEMA_STORAGE_KEY, DEFAULT_DEPOT_SCHEMA);
   });
+
+  if (workerInput) {
+    document.getElementById("btn-save-worker")?.addEventListener("click", () => {
+      const value = workerInput.value.trim();
+      if (!value) {
+        saveWorkerUrl("");
+        alert("Worker URL cleared – default will be used.");
+        return;
+      }
+      try {
+        const url = new URL(value);
+        if (!/^https?:$/i.test(url.protocol)) {
+          throw new Error("Worker URL must use http or https.");
+        }
+      } catch (e) {
+        alert("Worker URL invalid: " + (e?.message || e));
+        return;
+      }
+      saveWorkerUrl(value);
+      alert("Worker URL saved (local to this device).");
+    });
+
+    document.getElementById("btn-reset-worker")?.addEventListener("click", () => {
+      workerInput.value = DEFAULT_WORKER_URL;
+      saveWorkerUrl("");
+      alert("Worker URL reset to default.");
+    });
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- allow the app to load and persist a custom Worker URL in local storage
- read the stored Worker URL in the main notes page instead of the hard-coded value
- add settings UI controls so users can set or reset the Worker endpoint

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69166830cb60832cb779e1dc7bdb68bc)