### PR TITLE
feat(worker): trim Survey Brain model output before parsing

### DIFF
--- a/brain-worker.js
+++ b/brain-worker.js
@@ -248,9 +248,14 @@ Always preserve boiler/cylinder make & model exactly as spoken.
     throw new Error("No content from model");
   }
 
+  const trimmedContent = content.trim();
+  if (!trimmedContent) {
+    throw new Error("Model content was empty");
+  }
+
   let jsonOut;
   try {
-    jsonOut = JSON.parse(content);
+    jsonOut = JSON.parse(trimmedContent);
   } catch (err) {
     throw new Error(`Model content was not valid JSON: ${String(err)} :: ${content}`);
   }


### PR DESCRIPTION
## Summary
- trim whitespace from the chat completion content before JSON parsing
- guard against empty content to avoid downstream invalid JSON errors

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916c9c67100832c806f991d55f5aa27)