### PR TITLE
Remove hardcoded worker URL defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,7 +292,7 @@
 
   <script>
     // --- CONFIG / STORAGE KEYS ---
-    const DEFAULT_WORKER_URL = "https://depot-voice-notes.martinbibb.workers.dev";
+    const DEFAULT_WORKER_URL = "";
     const WORKER_URL_STORAGE_KEY = "depot.workerUrl";
     const SECTION_STORAGE_KEY = "depot.sectionSchema";
     const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
@@ -847,8 +847,23 @@
       try { return JSON.parse(JSON.stringify(val)); } catch (_) { return val; }
     }
 
+    function requireWorkerBaseUrl() {
+      const trimmed = (WORKER_URL || "").trim();
+      if (!trimmed) {
+        const err = new Error("Worker URL not configured");
+        err.voiceMessage = "Voice AI worker URL not configured. Update it in Settings.";
+        throw err;
+      }
+      if (!/^https?:\/\//i.test(trimmed)) {
+        const err = new Error("Worker URL must start with http:// or https://");
+        err.voiceMessage = "Voice AI worker URL looks invalid. Update it in Settings.";
+        throw err;
+      }
+      return trimmed.replace(/\/$/, "");
+    }
+
     async function postJSON(path, body) {
-      const base = WORKER_URL.replace(/\/$/, "");
+      const base = requireWorkerBaseUrl();
       const url = base + path;
       const res = await fetch(url, {
         method: "POST",
@@ -1388,7 +1403,8 @@
       clearVoiceError();
       try {
         const schemaSnapshot = await ensureSectionSchema();
-        const res = await fetch(WORKER_URL.replace(/\/$/, "") + "/audio", {
+        const baseUrl = requireWorkerBaseUrl();
+        const res = await fetch(baseUrl + "/audio", {
           method: "POST",
           headers: { "Content-Type": blob.type || "audio/webm" },
           body: blob

--- a/settings.html
+++ b/settings.html
@@ -275,7 +275,7 @@
     </section>
     <section>
       <h2>Worker endpoint</h2>
-      <p>Override the Cloudflare Worker URL used for Pro transcription. Leave blank to fall back to the default.</p>
+      <p>Set the Cloudflare Worker URL used for Pro transcription. Requests won't work until a valid URL is provided; leave blank to disable Pro features on this device.</p>
       <input id="settings-worker-url" type="url" placeholder="https://example.workers.dev" spellcheck="false" />
       <div class="btn-row">
         <button id="btn-save-worker">Save (this device)</button>

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -6,7 +6,7 @@ const LS_SCHEMA_KEY = "depot-output-schema";
 const LS_CHECKLIST_STATE_KEY = "depot-checklist-state";
 const LS_WORKER_URL_KEY = "depot-worker-url";
 
-export const DEFAULT_WORKER_URL = "https://survey-brain-api.martinbibb.workers.dev";
+export const DEFAULT_WORKER_URL = "";
 
 function deepClone(value) {
   if (value === undefined || value === null) {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -5,7 +5,7 @@ const CHECKLIST_CONFIG_URL = "../checklist.config.json";
 const WORKER_URL_STORAGE_KEY = "depot.workerUrl";
 const FUTURE_PLANS_NAME = "Future plans";
 const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
-const DEFAULT_WORKER_URL = "https://depot-voice-notes.martinbibb.workers.dev";
+const DEFAULT_WORKER_URL = "";
 
 function sanitiseSectionSchema(input) {
   const asArray = (value) => {


### PR DESCRIPTION
## Summary
- remove the hardcoded worker URL from the main app and settings defaults
- require a valid worker URL before allowing voice requests and show helpful errors when missing
- update the settings copy to explain that the worker URL must be configured

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177085ff44832c8a77227475fce6c5)