### PR TITLE
Populate Depot schema and checklist defaults

### DIFF
--- a/checklist.config.json
+++ b/checklist.config.json
@@ -2,6 +2,7 @@
   "sectionsOrder": [
     "Needs",
     "Working at heights",
+    "System characteristics",
     "Components that require assistance",
     "Restrictions to work",
     "External hazards",

--- a/depot.output.schema.json
+++ b/depot.output.schema.json
@@ -1,32 +1,72 @@
-{
-  "sectionsOrder": [
-    "Needs",
-    "Working at heights",
-    "Components that require assistance",
-    "Restrictions to work",
-    "External hazards",
-    "Delivery notes",
-    "Office notes",
-    "New boiler and controls",
-    "Flue",
-    "Pipe work",
-    "Disruption",
-    "Customer actions",
-    "Future plans"
-  ],
-  "sections": [
-    { "name": "Needs", "order": 1, "description": "Key needs or must-haves called out by the customer." },
-    { "name": "Working at heights", "order": 2, "description": "Ladders, loft access, towers, scaffolds or special access kit." },
-    { "name": "Components that require assistance", "order": 3, "description": "Items needing two-person lifts or specialist handling." },
-    { "name": "Restrictions to work", "order": 4, "description": "Parking limits, permits or building restrictions." },
-    { "name": "External hazards", "order": 5, "description": "Asbestos, hazards, aggressive pets or notable site risks." },
-    { "name": "Delivery notes", "order": 6, "description": "Delivery constraints, storage space and timings." },
-    { "name": "Office notes", "order": 7, "description": "For the office team: planning, conservation, notifications." },
-    { "name": "New boiler and controls", "order": 8, "description": "What is being fitted: boiler, controls, flushing, filters." },
-    { "name": "Flue", "order": 9, "description": "Flue position, routing, plume kits and terminals." },
-    { "name": "Pipe work", "order": 10, "description": "Gas, condensate and system pipe alterations." },
-    { "name": "Disruption", "order": 11, "description": "Power flush, draining, floor lifting or decorations impacted." },
-    { "name": "Customer actions", "order": 12, "description": "Things the customer has to sort before install." },
-    { "name": "Future plans", "order": 13, "description": "Notes about any future work or follow-on visits." }
-  ]
-}
+[
+  {
+    "name": "Needs",
+    "description": "Key needs or must-haves called out by the customer.",
+    "order": 1
+  },
+  {
+    "name": "Working at heights",
+    "description": "Ladders, loft access, towers, scaffolds or special access kit.",
+    "order": 2
+  },
+  {
+    "name": "System characteristics",
+    "description": "What is coming out and what is going in; key system details that affect experience.",
+    "order": 3
+  },
+  {
+    "name": "Components that require assistance",
+    "description": "Items needing two-person lifts or specialist handling.",
+    "order": 4
+  },
+  {
+    "name": "Restrictions to work",
+    "description": "Parking limits, permits or building restrictions (including permissions).",
+    "order": 5
+  },
+  {
+    "name": "External hazards",
+    "description": "Asbestos, hazards, aggressive pets or notable site risks.",
+    "order": 6
+  },
+  {
+    "name": "Delivery notes",
+    "description": "Delivery constraints, storage space and timings.",
+    "order": 7
+  },
+  {
+    "name": "Office notes",
+    "description": "For the office team: planning, conservation, notifications.",
+    "order": 8
+  },
+  {
+    "name": "New boiler and controls",
+    "description": "What is being fitted: boiler, controls, flushing, filters.",
+    "order": 9
+  },
+  {
+    "name": "Flue",
+    "description": "Flue position, routing, plume kits and terminals.",
+    "order": 10
+  },
+  {
+    "name": "Pipe work",
+    "description": "Gas, condensate and system pipe alterations.",
+    "order": 11
+  },
+  {
+    "name": "Disruption",
+    "description": "Where work happens, making good, expected mess/disruption.",
+    "order": 12
+  },
+  {
+    "name": "Customer actions",
+    "description": "What the customer has agreed to do before/after the job.",
+    "order": 13
+  },
+  {
+    "name": "Future plans",
+    "description": "Notes about any future work or follow-on visits.",
+    "order": 14
+  }
+]


### PR DESCRIPTION
## Summary
- update depot.output.schema.json to list all Depot sections with descriptions and ordering
- add the missing "System characteristics" entry to the default checklist section order so schema and checklist stay in sync

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177f57a1a4832c9b73e8787b38be3e)