### PR TITLE
Remove invented Depot schema descriptions

### DIFF
--- a/brain-worker.js
+++ b/brain-worker.js
@@ -410,7 +410,6 @@ import schemaConfig from "./depot.output.schema.json" assert { type: "json" };
 import checklistConfig from "./checklist.config.json" assert { type: "json" };
 
 const FUTURE_PLANS_NAME = "Future plans";
-const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
 
 function sanitiseSectionSchema(input) {
   const asArray = (value) => {
@@ -465,11 +464,14 @@ function sanitiseSectionSchema(input) {
   if (!future) {
     future = {
       name: FUTURE_PLANS_NAME,
-      description: FUTURE_PLANS_DESCRIPTION,
+      description: "",
       order: withoutFuture.length + 1
     };
-  } else if (!future.description) {
-    future = { ...future, description: FUTURE_PLANS_DESCRIPTION };
+  } else {
+    future = {
+      ...future,
+      description: future.description || ""
+    };
   }
 
   const final = [...withoutFuture, future].map((entry, idx) => ({

--- a/depot.output.schema.json
+++ b/depot.output.schema.json
@@ -1,72 +1,72 @@
 [
   {
     "name": "Needs",
-    "description": "Key needs or must-haves called out by the customer.",
+    "description": "",
     "order": 1
   },
   {
     "name": "Working at heights",
-    "description": "Ladders, loft access, towers, scaffolds or special access kit.",
+    "description": "",
     "order": 2
   },
   {
     "name": "System characteristics",
-    "description": "What is coming out and what is going in; key system details that affect experience.",
+    "description": "",
     "order": 3
   },
   {
     "name": "Components that require assistance",
-    "description": "Items needing two-person lifts or specialist handling.",
+    "description": "",
     "order": 4
   },
   {
     "name": "Restrictions to work",
-    "description": "Parking limits, permits or building restrictions (including permissions).",
+    "description": "",
     "order": 5
   },
   {
     "name": "External hazards",
-    "description": "Asbestos, hazards, aggressive pets or notable site risks.",
+    "description": "",
     "order": 6
   },
   {
     "name": "Delivery notes",
-    "description": "Delivery constraints, storage space and timings.",
+    "description": "",
     "order": 7
   },
   {
     "name": "Office notes",
-    "description": "For the office team: planning, conservation, notifications.",
+    "description": "",
     "order": 8
   },
   {
     "name": "New boiler and controls",
-    "description": "What is being fitted: boiler, controls, flushing, filters.",
+    "description": "",
     "order": 9
   },
   {
     "name": "Flue",
-    "description": "Flue position, routing, plume kits and terminals.",
+    "description": "",
     "order": 10
   },
   {
     "name": "Pipe work",
-    "description": "Gas, condensate and system pipe alterations.",
+    "description": "",
     "order": 11
   },
   {
     "name": "Disruption",
-    "description": "Where work happens, making good, expected mess/disruption.",
+    "description": "",
     "order": 12
   },
   {
     "name": "Customer actions",
-    "description": "What the customer has agreed to do before/after the job.",
+    "description": "",
     "order": 13
   },
   {
     "name": "Future plans",
-    "description": "Notes about any future work or follow-on visits.",
+    "description": "",
     "order": 14
   }
 ]

--- a/index.html
+++ b/index.html
@@ -302,7 +302,6 @@
     const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
     const LS_AUTOSAVE_KEY = "surveyBrainAutosave";
     const FUTURE_PLANS_NAME = "Future plans";
-    const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
 
     let WORKER_URL = loadWorkerEndpoint();
 
@@ -508,11 +507,14 @@
       if (!future) {
         future = {
           name: FUTURE_PLANS_NAME,
-          description: FUTURE_PLANS_DESCRIPTION,
+          description: "",
           order: withoutFuture.length + 1
         };
-      } else if (!future.description) {
-        future = { ...future, description: FUTURE_PLANS_DESCRIPTION };
+      } else {
+        future = {
+          ...future,
+          description: future.description || ""
+        };
       }
 
       const final = [...withoutFuture, future].map((entry, idx) => ({

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -8,7 +8,6 @@ const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
 const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
 const CHECKLIST_CONFIG_URL = "../checklist.config.json";
 const FUTURE_PLANS_NAME = "Future plans";
-const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
 const AUTOSAVE_STORAGE_KEY = "surveyBrainAutosave";
 const LEGACY_SCHEMA_STORAGE_KEY = "depot-output-schema";
 const CHECKLIST_STATE_STORAGE_KEY = "depot-checklist-state";
@@ -66,11 +65,14 @@ function sanitiseSectionSchema(input) {
   if (!future) {
     future = {
       name: FUTURE_PLANS_NAME,
-      description: FUTURE_PLANS_DESCRIPTION,
+      description: "",
       order: withoutFuture.length + 1
     };
-  } else if (!future.description) {
-    future = { ...future, description: FUTURE_PLANS_DESCRIPTION };
+  } else {
+    future = {
+      ...future,
+      description: future.description || ""
+    };
   }
 
   const final = [...withoutFuture, future].map((entry, idx) => ({
@@ -366,8 +368,10 @@ let cachedChecklistOrder = [];
 function ensureFuturePresence() {
   let idx = editableSchema.findIndex((entry) => entry.name === FUTURE_PLANS_NAME);
   if (idx === -1) {
-    editableSchema.push({ name: FUTURE_PLANS_NAME, description: FUTURE_PLANS_DESCRIPTION });
+    editableSchema.push({ name: FUTURE_PLANS_NAME, description: "" });
     idx = editableSchema.length - 1;
+  } else if (!editableSchema[idx].description) {
+    editableSchema[idx].description = "";
   }
   if (idx !== editableSchema.length - 1) {
     const [future] = editableSchema.splice(idx, 1);


### PR DESCRIPTION
## Summary
- strip opinionated descriptions from the default Depot section schema JSON
- stop the sanitisation helpers in the app, worker and settings UI from forcing a description onto the Future plans section
- ensure the settings editor keeps a Future plans row even when users clear its description

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691859638cc0832ca6c28e99360e2c11)