### PR TITLE
feat: centralise depot notes schema and dedupe notes output

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,11 +295,13 @@
       loadWorkerEndpoint,
       isWorkerEndpointStorageKey
     } from "./src/app/worker-config.js";
+    import {
+      loadDepotNotesSchema,
+      DEPOT_NOTES_SCHEMA_STORAGE_KEY
+    } from "./src/app/state.js";
 
     // --- CONFIG / STORAGE KEYS ---
-    const SECTION_STORAGE_KEY = "depot.sectionSchema";
-    const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
-    const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
+    const LEGACY_SCHEMA_KEYS = ["depot.sectionSchema", "surveybrain-schema", "depot-output-schema", "depot.checklistConfig"];
     const LS_AUTOSAVE_KEY = "surveyBrainAutosave";
     const FUTURE_PLANS_NAME = "Future plans";
 
@@ -341,7 +343,7 @@
     let SECTION_ORDER_MAP = new Map();
     let SECTION_KEY_LOOKUP = new Map();
     let schemaLoaded = false;
-    let CHECKLIST_SOURCE = [];
+    let CHECKLIST_SOURCE = { sectionsOrder: [], items: [] };
     let CHECKLIST_ITEMS = [];
 
     function sanitiseChecklistArray(value) {
@@ -384,41 +386,6 @@
       return cleaned;
     }
 
-    async function loadChecklistConfig() {
-      let defaultConfig = [];
-      try {
-        const res = await fetch("checklist.config.json", { cache: "no-store" });
-        if (res.ok) {
-          const data = await res.json();
-          defaultConfig = sanitiseChecklistArray(data);
-        }
-      } catch (err) {
-        console.warn("Failed to fetch default checklist", err);
-      }
-
-      let local = null;
-      try {
-        local = JSON.parse(localStorage.getItem(CHECKLIST_STORAGE_KEY) || "null");
-      } catch (_) {
-        local = null;
-      }
-
-      const localConfig = sanitiseChecklistArray(local);
-      const finalConfig = localConfig.length ? localConfig : defaultConfig;
-
-      return sanitiseChecklistArray(finalConfig);
-    }
-
-    function saveLocalChecklistConfig(cfg) {
-      const cleaned = sanitiseChecklistArray(cfg);
-      try {
-        localStorage.setItem(CHECKLIST_STORAGE_KEY, JSON.stringify(cleaned));
-      } catch (err) {
-        console.warn("Failed to persist checklist override", err);
-      }
-      return cleaned;
-    }
-
     let mediaRecorder = null;
     let mediaStream = null;
     let sessionAudioChunks = [];
@@ -439,128 +406,24 @@
     let pendingFinishSend = false;
 
     // --- HELPERS ---
-    function readStoredSectionOverride() {
-      const keys = [SECTION_STORAGE_KEY, LEGACY_SECTION_STORAGE_KEY];
-      for (let i = 0; i < keys.length; i += 1) {
-        const key = keys[i];
-        try {
-          const raw = localStorage.getItem(key);
-          if (!raw) continue;
-          return JSON.parse(raw);
-        } catch (_) {
-          continue;
-        }
-      }
-      return null;
-    }
-
-    function sanitiseSectionSchema(input) {
-      const asArray = (value) => {
-        if (!value) return [];
-        if (Array.isArray(value)) return value;
-        if (value && typeof value === "object" && Array.isArray(value.sections)) {
-          return value.sections;
-        }
-        return [];
-      };
-
-      const rawEntries = asArray(input);
-      const prepared = [];
-      rawEntries.forEach((entry, idx) => {
-        if (!entry) return;
-        const rawName = entry.name ?? entry.section ?? entry.title ?? entry.heading;
-        const name = typeof rawName === "string" ? rawName.trim() : "";
-        if (!name || name === "Arse_cover_notes") return;
-        const rawDescription = entry.description ?? entry.hint ?? "";
-        const description = typeof rawDescription === "string"
-          ? rawDescription.trim()
-          : String(rawDescription || "").trim();
-        const order = typeof entry.order === "number" ? entry.order : idx + 1;
-        prepared.push({ name, description, order, idx });
-      });
-
-      prepared.sort((a, b) => {
-        const aHasOrder = typeof a.order === "number";
-        const bHasOrder = typeof b.order === "number";
-        if (aHasOrder && bHasOrder && a.order !== b.order) {
-          return a.order - b.order;
-        }
-        if (aHasOrder && !bHasOrder) return -1;
-        if (!aHasOrder && bHasOrder) return 1;
-        return a.idx - b.idx;
-      });
-
-      const unique = [];
-      const seen = new Set();
-      prepared.forEach((entry) => {
-        if (seen.has(entry.name)) return;
-        seen.add(entry.name);
-        unique.push({
-          name: entry.name,
-          description: entry.description || "",
-          order: entry.order
-        });
-      });
-
-      let withoutFuture = unique.filter((entry) => entry.name !== FUTURE_PLANS_NAME);
-      let future = unique.find((entry) => entry.name === FUTURE_PLANS_NAME);
-      if (!future) {
-        future = {
-          name: FUTURE_PLANS_NAME,
-          description: "",
-          order: withoutFuture.length + 1
-        };
-      } else {
-        future = {
-          ...future,
-          description: future.description || ""
-        };
-      }
-
-      const final = [...withoutFuture, future].map((entry, idx) => ({
-        name: entry.name,
-        description: entry.description || "",
-        order: idx + 1
-      }));
-
-      return final;
-    }
-
-    async function loadSectionSchema() {
-      let defaultSchema = [];
-      try {
-        const res = await fetch("depot.output.schema.json", { cache: "no-store" });
-        if (res.ok) {
-          const json = await res.json();
-          defaultSchema = sanitiseSectionSchema(json);
-        }
-      } catch (err) {
-        console.warn("Failed to load default section schema", err);
-      }
-
-      let localOverride = null;
-      try {
-        localOverride = readStoredSectionOverride();
-      } catch (_) {
-        localOverride = null;
-      }
-
-      const candidate = Array.isArray(localOverride) && localOverride.length > 0
-        ? sanitiseSectionSchema(localOverride)
-        : defaultSchema;
-
-      if (candidate.length) {
-        return candidate;
-      }
-      return sanitiseSectionSchema([]);
-    }
-
-    function rebuildSectionState(schema) {
-      SECTION_SCHEMA = Array.isArray(schema) ? schema.map((entry, idx) => ({
-        name: entry.name,
-        description: entry.description || "",
-        order: typeof entry.order === "number" ? entry.order : idx + 1
-      })) : [];
+    function rebuildSectionState(sectionNames = []) {
+      const names = Array.isArray(sectionNames) ? sectionNames : [];
+      SECTION_SCHEMA = names
+        .map((entry, idx) => {
+          if (!entry) return null;
+          const name = typeof entry === "string"
+            ? entry.trim()
+            : entry && typeof entry === "object" && entry.name
+              ? String(entry.name).trim()
+              : "";
+          if (!name) return null;
+          return {
+            name,
+            description: "",
+            order: idx + 1
+          };
+        })
+        .filter(Boolean);
       SECTION_NAMES = SECTION_SCHEMA.map((entry) => entry.name);
       SECTION_ORDER_MAP = new Map();
       SECTION_KEY_LOOKUP = new Map();
@@ -590,12 +453,42 @@
       schemaLoaded = SECTION_SCHEMA.length > 0;
     }
 
+    function applyDepotNotesSchema(rawSchema) {
+      const sections = Array.isArray(rawSchema?.sections) ? rawSchema.sections : [];
+      rebuildSectionState(sections);
+
+      const checklistSource = rawSchema && typeof rawSchema === "object" && rawSchema.checklist
+        ? rawSchema.checklist
+        : {};
+      const items = sanitiseChecklistArray(checklistSource);
+      const seen = new Set();
+      const order = [];
+      (Array.isArray(checklistSource.sectionsOrder) ? checklistSource.sectionsOrder : []).forEach((name) => {
+        const trimmed = typeof name === "string" ? name.trim() : String(name || "").trim();
+        if (!trimmed || seen.has(trimmed) || !SECTION_NAMES.includes(trimmed)) return;
+        seen.add(trimmed);
+        order.push(trimmed);
+      });
+      SECTION_NAMES.forEach((name) => {
+        if (!seen.has(name)) {
+          seen.add(name);
+          order.push(name);
+        }
+      });
+
+      CHECKLIST_SOURCE = {
+        sectionsOrder: order,
+        items
+      };
+      CHECKLIST_ITEMS = normaliseChecklistConfig(CHECKLIST_SOURCE);
+    }
+
     async function ensureSectionSchema() {
       if (schemaLoaded && SECTION_SCHEMA.length) {
         return SECTION_SCHEMA;
       }
-      const schema = await loadSectionSchema();
-      rebuildSectionState(schema);
+      const schema = loadDepotNotesSchema();
+      applyDepotNotesSchema(schema);
       return SECTION_SCHEMA;
     }
 
@@ -652,18 +545,89 @@
       return String(value);
     }
 
-    function mergeTextFields(existing, incoming) {
-      const prev = typeof existing === "string" ? existing : "";
-      const next = typeof incoming === "string" ? incoming : "";
-      const prevTrim = prev.trim();
-      const nextTrim = next.trim();
-      if (!prevTrim && !nextTrim) return next || prev || "";
-      if (!prevTrim) return next;
-      if (!nextTrim) return prev;
-      if (prevTrim.toLowerCase() === nextTrim.toLowerCase()) return next || prev;
-      if (prevTrim.includes(nextTrim)) return prev;
-      if (nextTrim.includes(prevTrim)) return next;
-      return `${prevTrim}\n${nextTrim}`.trim();
+    const SECTION_PLACEHOLDER_KEY = "no additional notes";
+
+    function normaliseClauseKey(text) {
+      return String(text || "")
+        .replace(/^•\s*/, "")
+        .replace(/[.;:\s]+$/g, "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+    }
+
+    function splitPlainClauses(raw) {
+      return String(raw || "")
+        .split(/[;\n]+/)
+        .map((part) => part.replace(/^•\s*/, "").trim())
+        .filter(Boolean);
+    }
+
+    function preparePlainText(raw) {
+      const clauses = splitPlainClauses(raw);
+      if (!clauses.length) {
+        return { text: "", hasMeaningful: false, hasAny: false };
+      }
+      const seen = new Set();
+      const deduped = [];
+      clauses.forEach((clause) => {
+        const key = normaliseClauseKey(clause);
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        deduped.push(clause);
+      });
+      const hasMeaningful = deduped.some((clause) => normaliseClauseKey(clause) !== SECTION_PLACEHOLDER_KEY);
+      const filtered = hasMeaningful
+        ? deduped.filter((clause) => normaliseClauseKey(clause) !== SECTION_PLACEHOLDER_KEY)
+        : deduped;
+      const text = filtered
+        .map((clause) => {
+          const trimmed = clause.trim();
+          if (!trimmed) return "";
+          return trimmed.endsWith(";") ? trimmed : `${trimmed};`;
+        })
+        .filter(Boolean)
+        .join(" ");
+      return {
+        text,
+        hasMeaningful,
+        hasAny: filtered.length > 0
+      };
+    }
+
+    function normaliseNaturalKey(text) {
+      return String(text || "")
+        .replace(/[.]+$/g, "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+    }
+
+    function prepareNaturalLanguage(raw) {
+      const parts = String(raw || "")
+        .split(/\n+/)
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (!parts.length) {
+        return { text: "", hasMeaningful: false, hasAny: false };
+      }
+      const seen = new Set();
+      const deduped = [];
+      parts.forEach((part) => {
+        const key = normaliseNaturalKey(part);
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        deduped.push(part);
+      });
+      const hasMeaningful = deduped.some((part) => normaliseNaturalKey(part) !== SECTION_PLACEHOLDER_KEY);
+      const filtered = hasMeaningful
+        ? deduped.filter((part) => normaliseNaturalKey(part) !== SECTION_PLACEHOLDER_KEY)
+        : deduped;
+      return {
+        text: filtered.join("\n"),
+        hasMeaningful,
+        hasAny: filtered.length > 0
+      };
     }
 
     function normaliseSectionCandidate(section, index = 0) {
@@ -691,22 +655,6 @@
       };
     }
 
-    function mergeIncomingSection(existing, incoming) {
-      if (!incoming) return existing || null;
-      if (!existing) {
-        return {
-          section: incoming.section,
-          plainText: typeof incoming.plainText === "string" ? incoming.plainText : "",
-          naturalLanguage: typeof incoming.naturalLanguage === "string" ? incoming.naturalLanguage : ""
-        };
-      }
-      return {
-        section: incoming.section || existing.section,
-        plainText: mergeTextFields(existing.plainText, incoming.plainText),
-        naturalLanguage: mergeTextFields(existing.naturalLanguage, incoming.naturalLanguage)
-      };
-    }
-
     function partitionSectionsByRequirement(sections) {
       const required = new Map();
       const extras = new Map();
@@ -714,15 +662,12 @@
         const normalised = normaliseSectionCandidate(section, idx);
         if (!normalised) return;
         if (normalised.isRequired) {
-          const existing = required.get(normalised.section);
-          required.set(normalised.section, mergeIncomingSection(existing, normalised));
+          required.set(normalised.section, normalised);
         } else {
           const key = normaliseSectionKey(normalised.originalName || normalised.section) || `${idx}-${normalised.section}`;
-          const existingExtra = extras.get(key);
-          const merged = mergeIncomingSection(existingExtra && existingExtra.entry, normalised);
           extras.set(key, {
-            entry: merged,
-            order: existingExtra ? existingExtra.order : idx
+            entry: normalised,
+            order: idx
           });
         }
       });
@@ -730,15 +675,45 @@
     }
 
     function combineSectionEntries(prev, next, sectionName) {
-      const plainText = mergeTextFields(prev && prev.plainText, next && next.plainText);
-      const naturalLanguage = mergeTextFields(prev && prev.naturalLanguage, next && next.naturalLanguage);
-      if (!plainText.trim() && !naturalLanguage.trim()) {
+      const prevPlain = preparePlainText(prev && prev.plainText);
+      const prevNatural = prepareNaturalLanguage(prev && prev.naturalLanguage);
+      const nextPlain = preparePlainText(next && next.plainText);
+      const nextNatural = prepareNaturalLanguage(next && next.naturalLanguage);
+
+      const nextHasMeaningful = nextPlain.hasMeaningful || nextNatural.hasMeaningful;
+      const prevHasMeaningful = prevPlain.hasMeaningful || prevNatural.hasMeaningful;
+
+      if (nextHasMeaningful) {
+        if (!nextPlain.text && !nextNatural.text && !nextPlain.hasAny && !nextNatural.hasAny) {
+          return null;
+        }
+        return {
+          section: sectionName,
+          plainText: nextPlain.text,
+          naturalLanguage: nextNatural.text
+        };
+      }
+
+      if (prevHasMeaningful) {
+        if (!prevPlain.text && !prevNatural.text && !prevPlain.hasAny && !prevNatural.hasAny) {
+          return null;
+        }
+        return {
+          section: sectionName,
+          plainText: prevPlain.text,
+          naturalLanguage: prevNatural.text
+        };
+      }
+
+      const fallbackPlain = nextPlain.text || prevPlain.text;
+      const fallbackNatural = nextNatural.text || prevNatural.text;
+      if (!fallbackPlain && !fallbackNatural) {
         return null;
       }
       return {
         section: sectionName,
-        plainText,
-        naturalLanguage
+        plainText: fallbackPlain,
+        naturalLanguage: fallbackNatural
       };
     }
 
@@ -1084,13 +1059,25 @@
       return s.trim();
     }
     function bulletify(lines){
-      const out=[];
+      const deduped=[];
+      const seen=new Set();
+      const placeholders=[];
       for (let raw of lines){
-        const t = stripPreamble(raw);
+        const t=stripPreamble(raw);
         if (!t) continue;
-        out.push("• " + ensureSemi(t));
+        const key=normaliseClauseKey(t);
+        if (!key || seen.has(key)) continue;
+        seen.add(key);
+        if (key===SECTION_PLACEHOLDER_KEY){
+          placeholders.push(t);
+        } else {
+          deduped.push(t);
+        }
       }
-      return out.join("\n");
+      if (!deduped.length && placeholders.length){
+        deduped.push(...placeholders);
+      }
+      return deduped.map((t)=>"• "+ensureSemi(t)).join("\n");
     }
     function formatPlainTextForSection(section, plain){
       if (!plain) return "";
@@ -1278,6 +1265,27 @@
       renderChecklist(clarificationsEl, lastCheckedItems, lastMissingInfo);
     }
 
+    function buildExportSections() {
+      const names = SECTION_NAMES.length ? SECTION_NAMES : SECTION_SCHEMA.map((entry) => entry.name);
+      const lookup = new Map();
+      (lastSections || []).forEach((sec) => {
+        if (!sec || !sec.section) return;
+        lookup.set(sec.section, {
+          section: sec.section,
+          plainText: sec.plainText || "",
+          naturalLanguage: sec.naturalLanguage || ""
+        });
+      });
+      return names.map((name) => {
+        const entry = lookup.get(name);
+        return {
+          section: name,
+          plainText: entry ? entry.plainText : "",
+          naturalLanguage: entry ? entry.naturalLanguage : ""
+        };
+      });
+    }
+
     function applyVoiceResult(result) {
       if (!result || typeof result !== "object") {
         showVoiceError("AI gave an empty result.");
@@ -1437,7 +1445,7 @@
       setStatus("Preparing notes…");
       const payload = {
         exportedAt: new Date().toISOString(),
-        sections: lastSections || []
+        sections: buildExportSections()
       };
       const pretty = JSON.stringify(payload, null, 2);
       const blob = new Blob([pretty], { type: "application/json" });
@@ -1930,27 +1938,14 @@
       try {
         await ensureSectionSchema();
       } catch (err) {
-        console.warn("Falling back to minimal schema", err);
-        const fallback = sanitiseSectionSchema([]);
-        rebuildSectionState(fallback);
+        console.warn("Failed to load depot notes schema", err);
+        applyDepotNotesSchema({ sections: [], checklist: { sectionsOrder: [], items: [] } });
       }
-    }
-
-    async function loadChecklistConfigIntoState() {
-      try {
-        CHECKLIST_SOURCE = await loadChecklistConfig();
-      } catch (err) {
-        console.warn("Failed to load checklist config", err);
-        CHECKLIST_SOURCE = [];
-      }
-
-      CHECKLIST_ITEMS = normaliseChecklistConfig(CHECKLIST_SOURCE);
     }
 
     async function loadStaticConfig() {
       WORKER_URL = loadWorkerEndpoint();
       await ensureSchemaIntoState();
-      await loadChecklistConfigIntoState();
       refreshUiFromState();
     }
 
@@ -1964,17 +1959,11 @@
       if (isWorkerEndpointStorageKey(event.key)) {
         WORKER_URL = loadWorkerEndpoint();
       }
-      if (event.key === SECTION_STORAGE_KEY || event.key === LEGACY_SECTION_STORAGE_KEY) {
+      if (event.key === DEPOT_NOTES_SCHEMA_STORAGE_KEY || LEGACY_SCHEMA_KEYS.includes(event.key)) {
         clearCachedSchema();
         ensureSchemaIntoState().then(() => {
           refreshUiFromState();
         }).catch((err) => console.warn("Failed to refresh schema after storage event", err));
-      }
-      if (event.key === CHECKLIST_STORAGE_KEY) {
-        loadChecklistConfigIntoState().then(() => {
-          renderChecklist(clarificationsEl, lastCheckedItems, lastMissingInfo);
-          refreshUiFromState();
-        }).catch((err) => console.warn("Failed to refresh checklist after storage event", err));
       }
     });
 

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -9,9 +9,11 @@ import {
   clearWorkerEndpointOverride
 } from "./worker-config.js";
 
-const LS_CHECKLIST_CONFIG_KEY = "depot.checklistConfig";
-const LS_SCHEMA_KEY = "depot-output-schema";
+const LS_DEPOT_NOTES_SCHEMA_KEY = "settings.depotNotesSchema";
+const LEGACY_SECTION_KEYS = ["depot.sectionSchema", "surveybrain-schema", "depot-output-schema"];
+const LEGACY_CHECKLIST_KEYS = ["depot.checklistConfig"];
 const LS_CHECKLIST_STATE_KEY = "depot-checklist-state";
+const FUTURE_PLANS_NAME = "Future plans";
 
 function deepClone(value) {
   if (value === undefined || value === null) {
@@ -26,6 +28,148 @@ function deepClone(value) {
   }
   return JSON.parse(JSON.stringify(value));
 }
+
+function extractSectionNames(raw) {
+  if (!raw) return [];
+  const source = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && Array.isArray(raw.sections)
+      ? raw.sections
+      : raw && typeof raw === "object" && Array.isArray(raw.names)
+        ? raw.names
+        : [];
+  const seen = new Set();
+  const names = [];
+  source.forEach((entry) => {
+    let name = "";
+    if (typeof entry === "string") {
+      name = entry.trim();
+    } else if (entry && typeof entry === "object") {
+      const candidate = entry.name ?? entry.section ?? entry.title ?? entry.heading;
+      name = typeof candidate === "string" ? candidate.trim() : "";
+    }
+    if (!name || name.toLowerCase() === "arse_cover_notes" || seen.has(name)) return;
+    seen.add(name);
+    names.push(name);
+  });
+  return names;
+}
+
+function ensureFuturePlansLast(names) {
+  const seen = new Set();
+  const ordered = [];
+  names.forEach((name) => {
+    const trimmed = typeof name === "string" ? name.trim() : String(name || "").trim();
+    if (!trimmed || trimmed === FUTURE_PLANS_NAME || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    ordered.push(trimmed);
+  });
+  ordered.push(FUTURE_PLANS_NAME);
+  return ordered;
+}
+
+const DEFAULT_SECTION_NAMES = ensureFuturePlansLast(extractSectionNames(defaultDepotSchema));
+
+function normaliseSectionNames(raw) {
+  const base = extractSectionNames(raw);
+  const merged = base.length ? base.slice() : DEFAULT_SECTION_NAMES.slice();
+  const seen = new Set(merged);
+  DEFAULT_SECTION_NAMES.forEach((name) => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      merged.push(name);
+    }
+  });
+  return ensureFuturePlansLast(merged);
+}
+
+function normaliseChecklistItems(raw) {
+  const entries = Array.isArray(raw)
+    ? raw
+    : raw && typeof raw === "object" && Array.isArray(raw.items)
+      ? raw.items
+      : [];
+  const seen = new Set();
+  const items = [];
+  entries.forEach((item) => {
+    if (!item || typeof item !== "object") return;
+    const id = item.id != null ? String(item.id).trim() : "";
+    const label = item.label != null ? String(item.label).trim() : "";
+    if (!id || !label || seen.has(id)) return;
+    seen.add(id);
+    const section = item.section != null
+      ? String(item.section).trim()
+      : item.depotSection != null
+        ? String(item.depotSection).trim()
+        : "";
+    const materials = Array.isArray(item.materials)
+      ? item.materials
+          .map((mat) => {
+            if (!mat || typeof mat !== "object") return null;
+            const itemName = mat.item != null ? String(mat.item).trim() : "";
+            if (!itemName) return null;
+            const qtyNum = Number(mat.qty);
+            const qty = Number.isFinite(qtyNum) && qtyNum > 0 ? qtyNum : 1;
+            return {
+              category: mat.category != null ? String(mat.category).trim() : "Misc",
+              item: itemName,
+              qty,
+              notes: mat.notes != null ? String(mat.notes).trim() : ""
+            };
+          })
+          .filter(Boolean)
+      : [];
+    items.push({
+      id,
+      group: item.group != null ? String(item.group).trim() : "",
+      section,
+      depotSection: section || undefined,
+      label,
+      hint: item.hint != null ? String(item.hint).trim() : "",
+      plainText: item.plainText != null ? String(item.plainText).trim() : "",
+      naturalLanguage: item.naturalLanguage != null ? String(item.naturalLanguage).trim() : "",
+      materials
+    });
+  });
+  return items;
+}
+
+function normaliseChecklistConfig(raw, sectionNames = DEFAULT_SECTION_NAMES) {
+  const items = normaliseChecklistItems(raw);
+  const orderSource = raw && typeof raw === "object" && !Array.isArray(raw) && Array.isArray(raw.sectionsOrder)
+    ? raw.sectionsOrder
+    : [];
+  const canonical = Array.isArray(sectionNames) && sectionNames.length
+    ? sectionNames
+    : DEFAULT_SECTION_NAMES;
+  const seen = new Set();
+  const sectionsOrder = [];
+  orderSource.forEach((name) => {
+    const trimmed = typeof name === "string" ? name.trim() : String(name || "").trim();
+    if (!trimmed || seen.has(trimmed) || !canonical.includes(trimmed)) return;
+    seen.add(trimmed);
+    sectionsOrder.push(trimmed);
+  });
+  canonical.forEach((name) => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      sectionsOrder.push(name);
+    }
+  });
+  return {
+    sectionsOrder,
+    items
+  };
+}
+
+const DEFAULT_CHECKLIST = normaliseChecklistConfig(defaultChecklistConfig, DEFAULT_SECTION_NAMES);
+const BASE_DEPOT_NOTES_SCHEMA = {
+  sections: DEFAULT_SECTION_NAMES.slice(),
+  checklist: {
+    sectionsOrder: DEFAULT_CHECKLIST.sectionsOrder.slice(),
+    items: deepClone(DEFAULT_CHECKLIST.items)
+  }
+};
 
 function loadJsonOrDefault(key, fallback) {
   try {
@@ -46,30 +190,104 @@ function saveJson(key, value) {
   }
 }
 
+function readLegacySections() {
+  for (const key of LEGACY_SECTION_KEYS) {
+    const value = loadJsonOrDefault(key, null);
+    if (value) return value;
+  }
+  return null;
+}
+
+function readLegacyChecklist() {
+  for (const key of LEGACY_CHECKLIST_KEYS) {
+    const value = loadJsonOrDefault(key, null);
+    if (value) return value;
+  }
+  return null;
+}
+
+function sanitiseDepotNotesSchema(candidate) {
+  if (!candidate) return null;
+  const sectionsInput = candidate.sections ?? candidate.sectionNames ?? candidate;
+  const sections = normaliseSectionNames(sectionsInput);
+  const checklistSource = candidate.checklist ?? candidate.checklistConfig ?? candidate;
+  const checklist = normaliseChecklistConfig(checklistSource, sections);
+  if (!sections.length && !checklist.items.length) {
+    return null;
+  }
+  return {
+    sections,
+    checklist
+  };
+}
+
+function pruneLegacyKeys() {
+  [...LEGACY_SECTION_KEYS, ...LEGACY_CHECKLIST_KEYS].forEach((key) => {
+    if (!key) return;
+    try {
+      localStorage.removeItem(key);
+    } catch (_) {
+      // ignore storage failures
+    }
+  });
+}
+
+export function loadDepotNotesSchema() {
+  let schema = sanitiseDepotNotesSchema(loadJsonOrDefault(LS_DEPOT_NOTES_SCHEMA_KEY, null));
+
+  if (!schema) {
+    const legacySections = readLegacySections();
+    const sections = normaliseSectionNames(legacySections);
+    const legacyChecklist = readLegacyChecklist();
+    const checklist = normaliseChecklistConfig(legacyChecklist ?? defaultChecklistConfig, sections);
+    schema = { sections, checklist };
+  }
+
+  if (!schema || !schema.sections.length) {
+    schema = deepClone(BASE_DEPOT_NOTES_SCHEMA);
+  } else {
+    schema = {
+      sections: normaliseSectionNames(schema.sections),
+      checklist: normaliseChecklistConfig(schema.checklist, schema.sections)
+    };
+  }
+
+  const finalSchema = {
+    sections: schema.sections.slice(),
+    checklist: {
+      sectionsOrder: schema.checklist.sectionsOrder.slice(),
+      items: deepClone(schema.checklist.items)
+    }
+  };
+
+  saveJson(LS_DEPOT_NOTES_SCHEMA_KEY, finalSchema);
+  pruneLegacyKeys();
+
+  return deepClone(finalSchema);
+}
+
+export function saveDepotNotesSchema(value) {
+  const candidate = sanitiseDepotNotesSchema(value);
+  const finalSchema = candidate
+    ? {
+        sections: candidate.sections.slice(),
+        checklist: {
+          sectionsOrder: candidate.checklist.sectionsOrder.slice(),
+          items: deepClone(candidate.checklist.items)
+        }
+      }
+    : deepClone(BASE_DEPOT_NOTES_SCHEMA);
+  saveJson(LS_DEPOT_NOTES_SCHEMA_KEY, finalSchema);
+  pruneLegacyKeys();
+  return deepClone(finalSchema);
+}
+
 export function loadChecklistConfig() {
-  const fallback = deepClone(defaultChecklistConfig);
-  const stored = loadJsonOrDefault(LS_CHECKLIST_CONFIG_KEY, fallback);
-
-  if (Array.isArray(stored)) {
-    return { ...fallback, items: stored }; // legacy array-only overrides
-  }
-
-  if (stored && typeof stored === "object") {
-    const result = { ...fallback };
-    if (Array.isArray(stored.sectionsOrder)) {
-      result.sectionsOrder = stored.sectionsOrder.slice();
-    }
-    if (Array.isArray(stored.items)) {
-      result.items = stored.items.slice();
-    }
-    return result;
-  }
-
-  return fallback;
+  return loadDepotNotesSchema().checklist;
 }
 
 export function loadDepotSchema() {
-  return loadJsonOrDefault(LS_SCHEMA_KEY, defaultDepotSchema);
+  return loadDepotNotesSchema().sections.map((name, idx) => ({ name, order: idx + 1 }));
 }
 
 export function loadChecklistState() {
@@ -103,8 +321,10 @@ export function saveWorkerUrl(url) {
 
 export const DEFAULT_CHECKLIST_CONFIG = defaultChecklistConfig;
 export const DEFAULT_DEPOT_SCHEMA = defaultDepotSchema;
-export const CHECKLIST_CONFIG_STORAGE_KEY = LS_CHECKLIST_CONFIG_KEY;
-export const DEPOT_SCHEMA_STORAGE_KEY = LS_SCHEMA_KEY;
+export const DEFAULT_DEPOT_NOTES_SCHEMA = BASE_DEPOT_NOTES_SCHEMA;
+export const CHECKLIST_CONFIG_STORAGE_KEY = LS_DEPOT_NOTES_SCHEMA_KEY;
+export const DEPOT_SCHEMA_STORAGE_KEY = LS_DEPOT_NOTES_SCHEMA_KEY;
+export const DEPOT_NOTES_SCHEMA_STORAGE_KEY = LS_DEPOT_NOTES_SCHEMA_KEY;
 export const WORKER_URL_STORAGE_KEY = WORKER_ENDPOINT_STORAGE_KEY;
 export const WORKER_URL_STORAGE_KEYS = WORKER_ENDPOINT_STORAGE_KEYS;
 export const DEFAULT_WORKER_URL = DEFAULT_WORKER_ENDPOINT;

--- a/src/notes/notesEngine.js
+++ b/src/notes/notesEngine.js
@@ -1,8 +1,86 @@
-import { loadChecklistConfig, loadDepotSchema } from "../app/state.js";
+import { loadDepotNotesSchema } from "../app/state.js";
+
+const PLACEHOLDER_KEY = "no additional notes";
+
+function normaliseClauseKey(text) {
+  return String(text || "")
+    .replace(/^•\s*/, "")
+    .replace(/[.;:\s]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function extractPlainClauses(chunks = []) {
+  const seen = new Set();
+  const clauses = [];
+  (Array.isArray(chunks) ? chunks : []).forEach((chunk) => {
+    String(chunk || "")
+      .split(/[;\n]+/)
+      .map((part) => part.replace(/^•\s*/, "").trim())
+      .filter(Boolean)
+      .forEach((clause) => {
+        const key = normaliseClauseKey(clause);
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        clauses.push(clause);
+      });
+  });
+  const hasMeaningful = clauses.some((clause) => normaliseClauseKey(clause) !== PLACEHOLDER_KEY);
+  if (!hasMeaningful) {
+    return clauses;
+  }
+  return clauses.filter((clause) => normaliseClauseKey(clause) !== PLACEHOLDER_KEY);
+}
+
+function joinPlainClauses(clauses) {
+  if (!Array.isArray(clauses) || !clauses.length) return "";
+  return clauses
+    .map((clause) => {
+      const trimmed = clause.trim();
+      if (!trimmed) return "";
+      return trimmed.endsWith(";") ? trimmed : `${trimmed};`;
+    })
+    .filter(Boolean)
+    .join(" ");
+}
+
+function buildPlainTextFromChunks(chunks) {
+  return joinPlainClauses(extractPlainClauses(chunks));
+}
+
+function normaliseNaturalKey(text) {
+  return String(text || "")
+    .replace(/[.]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function buildNaturalLanguageFromChunks(chunks = []) {
+  const seen = new Set();
+  const parts = [];
+  (Array.isArray(chunks) ? chunks : []).forEach((chunk) => {
+    String(chunk || "")
+      .split(/\n+/)
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .forEach((part) => {
+        const key = normaliseNaturalKey(part);
+        if (!key || seen.has(key)) return;
+        seen.add(key);
+        parts.push(part);
+      });
+  });
+  const hasMeaningful = parts.some((part) => normaliseNaturalKey(part) !== PLACEHOLDER_KEY);
+  const filtered = hasMeaningful
+    ? parts.filter((part) => normaliseNaturalKey(part) !== PLACEHOLDER_KEY)
+    : parts;
+  return filtered.join("\n");
+}
 
 export function buildDepotOutputFromChecklist(checklistState = {}) {
-  const checklistConfig = loadChecklistConfig();
-  const depotSchema = loadDepotSchema();
+  const { sections: sectionOrder = [], checklist: checklistConfig = {} } = loadDepotNotesSchema();
 
   const sectionsMap = new Map();
   const materials = [];
@@ -45,28 +123,23 @@ export function buildDepotOutputFromChecklist(checklistState = {}) {
   });
 
   const sections = [];
-  const order = (depotSchema && depotSchema.sectionsOrder) || (checklistConfig && checklistConfig.sectionsOrder) || [];
+  const order = Array.isArray(sectionOrder) && sectionOrder.length
+    ? sectionOrder
+    : Array.isArray(checklistConfig.sectionsOrder)
+      ? checklistConfig.sectionsOrder
+      : [];
 
   order.forEach((sectionName) => {
     const bucket = sectionsMap.get(sectionName);
     if (!bucket) return;
-    const plainText = bucket.plain.join("; ");
-    const naturalLanguage = bucket.nl.join(" ");
+    const plainText = buildPlainTextFromChunks(bucket.plain);
+    const naturalLanguage = buildNaturalLanguageFromChunks(bucket.nl);
     if (!plainText && !naturalLanguage) return;
     sections.push({
       section: sectionName,
       plainText,
       naturalLanguage
     });
-  });
-
-  // Include any sections not explicitly ordered (fallback)
-  sectionsMap.forEach((bucket, name) => {
-    if (order.includes(name)) return;
-    const plainText = bucket.plain.join("; ");
-    const naturalLanguage = bucket.nl.join(" ");
-    if (!plainText && !naturalLanguage) return;
-    sections.push({ section: name, plainText, naturalLanguage });
   });
 
   return {

--- a/src/settings/settings.js
+++ b/src/settings/settings.js
@@ -1,278 +1,197 @@
 import {
+  loadDepotNotesSchema,
+  saveDepotNotesSchema,
+  DEFAULT_DEPOT_NOTES_SCHEMA,
+  DEPOT_NOTES_SCHEMA_STORAGE_KEY
+} from "../app/state.js";
+import {
   WORKER_ENDPOINT_STORAGE_KEYS,
   clearWorkerEndpointOverride
 } from "../app/worker-config.js";
 
-const SECTION_STORAGE_KEY = "depot.sectionSchema";
-const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
-const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
-const CHECKLIST_CONFIG_URL = "../checklist.config.json";
-const FUTURE_PLANS_NAME = "Future plans";
-const AUTOSAVE_STORAGE_KEY = "surveyBrainAutosave";
-const LEGACY_SCHEMA_STORAGE_KEY = "depot-output-schema";
-const CHECKLIST_STATE_STORAGE_KEY = "depot-checklist-state";
+const schemaTextarea = document.getElementById("settings-schema-json");
+const checklistTextarea = document.getElementById("settings-checklist-json");
+const sectionSummaryEl = document.getElementById("settings-section-editor");
+const checklistSummaryEl = document.getElementById("checklist-editor");
+const saveSchemaBtn = document.getElementById("btn-save-schema");
+const resetSchemaBtn = document.getElementById("btn-reset-schema");
+const saveChecklistBtn = document.getElementById("btn-save-checklist");
+const resetChecklistBtn = document.getElementById("btn-reset-checklist");
+const forceReloadBtn = document.getElementById("btn-force-reload");
 
-function sanitiseSectionSchema(input) {
-  const asArray = (value) => {
-    if (!value) return [];
-    if (Array.isArray(value)) return value;
-    if (value && typeof value === "object" && Array.isArray(value.sections)) {
-      return value.sections;
+const LEGACY_STORAGE_KEYS = [
+  "depot.sectionSchema",
+  "surveybrain-schema",
+  "depot-output-schema",
+  "depot.checklistConfig",
+  "surveyBrainAutosave",
+  "depot-checklist-state"
+];
+
+function deepClone(value) {
+  if (value === null || value === undefined) return value;
+  if (typeof structuredClone === "function") {
+    try {
+      return structuredClone(value);
+    } catch (_) {
+      // fall back to JSON clone
     }
-    return [];
-  };
+  }
+  return JSON.parse(JSON.stringify(value));
+}
 
-  const rawEntries = asArray(input);
-  const prepared = [];
-  rawEntries.forEach((entry, idx) => {
-    if (!entry) return;
-    const rawName = entry.name ?? entry.section ?? entry.title ?? entry.heading;
-    const name = typeof rawName === "string" ? rawName.trim() : "";
-    if (!name || name === "Arse_cover_notes") return;
-    const rawDescription = entry.description ?? entry.hint ?? "";
-    const description = typeof rawDescription === "string"
-      ? rawDescription.trim()
-      : String(rawDescription || "").trim();
-    const order = typeof entry.order === "number" ? entry.order : idx + 1;
-    prepared.push({ name, description, order, idx });
-  });
+function cloneDefaultSchema() {
+  const defaults = DEFAULT_DEPOT_NOTES_SCHEMA || {};
+  const sections = Array.isArray(defaults.sections) ? defaults.sections.slice() : [];
+  const checklist = defaults.checklist && typeof defaults.checklist === "object"
+    ? {
+        sectionsOrder: Array.isArray(defaults.checklist.sectionsOrder)
+          ? defaults.checklist.sectionsOrder.slice()
+          : [],
+        items: Array.isArray(defaults.checklist.items)
+          ? deepClone(defaults.checklist.items)
+          : []
+      }
+    : { sectionsOrder: [], items: [] };
+  return { sections, checklist };
+}
 
-  prepared.sort((a, b) => {
-    const aHasOrder = typeof a.order === "number";
-    const bHasOrder = typeof b.order === "number";
-    if (aHasOrder && bHasOrder && a.order !== b.order) {
-      return a.order - b.order;
-    }
-    if (aHasOrder && !bHasOrder) return -1;
-    if (!aHasOrder && bHasOrder) return 1;
-    return a.idx - b.idx;
-  });
+function renderSectionSummary(sections = []) {
+  if (!sectionSummaryEl) return;
+  if (!sections.length) {
+    sectionSummaryEl.innerHTML = '<p class="small">No sections configured.</p>';
+    return;
+  }
+  const items = sections
+    .map((name, idx) => `<li><strong>${idx + 1}.</strong> ${name}</li>`)
+    .join("");
+  sectionSummaryEl.innerHTML = `<ol>${items}</ol>`;
+}
 
-  const unique = [];
-  const seen = new Set();
-  prepared.forEach((entry) => {
-    if (seen.has(entry.name)) return;
-    seen.add(entry.name);
-    unique.push({
-      name: entry.name,
-      description: entry.description || "",
-      order: entry.order
+function renderChecklistSummary(checklist = {}) {
+  if (!checklistSummaryEl) return;
+  const items = Array.isArray(checklist.items) ? checklist.items : [];
+  const total = items.length;
+  const preview = items.slice(0, 5).map((item) => {
+    const label = item && (item.label || item.id || "Item");
+    const section = item && item.section ? ` <span class="small">(${item.section})</span>` : "";
+    return `<li>${label}${section}</li>`;
+  }).join("");
+  const more = total > 5 ? "<li>…</li>" : "";
+  const order = Array.isArray(checklist.sectionsOrder) && checklist.sectionsOrder.length
+    ? checklist.sectionsOrder.join(" › ")
+    : "(none)";
+  checklistSummaryEl.innerHTML = `
+    <p><strong>${total}</strong> checklist items configured.</p>
+    <p class="small">Sections order: ${order}</p>
+    ${total ? `<ul>${preview}${more}</ul>` : '<p class="small">No checklist items configured.</p>'}
+  `;
+}
+
+function renderSummaries(schema) {
+  renderSectionSummary(schema.sections);
+  renderChecklistSummary(schema.checklist);
+}
+
+function refreshForm() {
+  const schema = loadDepotNotesSchema();
+  if (schemaTextarea) {
+    schemaTextarea.value = JSON.stringify(schema.sections, null, 2);
+  }
+  if (checklistTextarea) {
+    checklistTextarea.value = JSON.stringify(schema.checklist, null, 2);
+  }
+  renderSummaries(schema);
+}
+
+function parseJsonInput(rawValue, fallback) {
+  if (!rawValue || !rawValue.trim()) return fallback;
+  try {
+    return JSON.parse(rawValue);
+  } catch (err) {
+    throw new Error(`Invalid JSON: ${err?.message || err}`);
+  }
+}
+
+function handleSaveSections() {
+  if (!schemaTextarea) return;
+  try {
+    const parsed = parseJsonInput(schemaTextarea.value, []);
+    const current = loadDepotNotesSchema();
+    saveDepotNotesSchema({
+      sections: parsed,
+      checklist: current.checklist
     });
+    refreshForm();
+  } catch (err) {
+    alert(err.message || "Unable to save sections");
+  }
+}
+
+function handleSaveChecklist() {
+  if (!checklistTextarea) return;
+  try {
+    const parsed = parseJsonInput(checklistTextarea.value, { sectionsOrder: [], items: [] });
+    const current = loadDepotNotesSchema();
+    saveDepotNotesSchema({
+      sections: current.sections,
+      checklist: parsed
+    });
+    refreshForm();
+  } catch (err) {
+    alert(err.message || "Unable to save checklist");
+  }
+}
+
+function handleResetSections() {
+  const defaults = cloneDefaultSchema();
+  const current = loadDepotNotesSchema();
+  saveDepotNotesSchema({
+    sections: defaults.sections,
+    checklist: current.checklist
   });
-
-  let withoutFuture = unique.filter((entry) => entry.name !== FUTURE_PLANS_NAME);
-  let future = unique.find((entry) => entry.name === FUTURE_PLANS_NAME);
-  if (!future) {
-    future = {
-      name: FUTURE_PLANS_NAME,
-      description: "",
-      order: withoutFuture.length + 1
-    };
-  } else {
-    future = {
-      ...future,
-      description: future.description || ""
-    };
-  }
-
-  const final = [...withoutFuture, future].map((entry, idx) => ({
-    name: entry.name,
-    description: entry.description || "",
-    order: idx + 1
-  }));
-
-  return final;
+  refreshForm();
 }
 
-async function loadSectionSchema() {
-  let defaultSchema = [];
-  try {
-    const res = await fetch("../depot.output.schema.json", { cache: "no-store" });
-    if (res.ok) {
-      const json = await res.json();
-      defaultSchema = sanitiseSectionSchema(json);
-    }
-  } catch (err) {
-    console.warn("Failed to fetch default schema", err);
-  }
-
-  let local = null;
-  try {
-    const keys = [SECTION_STORAGE_KEY, LEGACY_SECTION_STORAGE_KEY];
-    for (const key of keys) {
-      const raw = localStorage.getItem(key);
-      if (!raw) continue;
-      local = JSON.parse(raw);
-      break;
-    }
-  } catch (err) {
-    console.warn("Failed to read local schema override", err);
-  }
-
-  const candidate = Array.isArray(local) && local.length
-    ? sanitiseSectionSchema(local)
-    : defaultSchema;
-
-  if (candidate.length) {
-    return candidate;
-  }
-  return sanitiseSectionSchema([]);
-}
-
-function saveLocalSectionSchema(schema) {
-  const final = sanitiseSectionSchema(schema);
-  try {
-    localStorage.setItem(SECTION_STORAGE_KEY, JSON.stringify(final));
-    localStorage.removeItem(LEGACY_SECTION_STORAGE_KEY);
-  } catch (err) {
-    alert("Unable to save schema: " + (err?.message || err));
-  }
-  return final;
-}
-
-function sanitiseChecklistArray(value) {
-  const asArray = (input) => {
-    if (!input) return [];
-    if (Array.isArray(input)) return input;
-    if (input && typeof input === "object" && Array.isArray(input.items)) {
-      return input.items;
-    }
-    return [];
-  };
-
-  const entries = asArray(value);
-  const seen = new Set();
-  const cleaned = [];
-
-  entries.forEach((item) => {
-    if (!item) return;
-    const copy = { ...item };
-    const id = copy.id != null ? String(copy.id).trim() : "";
-    const label = copy.label != null ? String(copy.label).trim() : "";
-    if (!id || !label || seen.has(id)) return;
-    seen.add(id);
-    copy.id = id;
-    copy.label = label;
-    copy.group = copy.group != null ? String(copy.group).trim() : "";
-    copy.hint = copy.hint != null ? String(copy.hint).trim() : "";
-    const section = copy.section != null && String(copy.section).trim()
-      ? String(copy.section).trim()
-      : copy.depotSection != null && String(copy.depotSection).trim()
-        ? String(copy.depotSection).trim()
-        : "";
-    copy.section = section;
-    if (section) {
-      copy.depotSection = section;
-    }
-    cleaned.push(copy);
+function handleResetChecklist() {
+  const defaults = cloneDefaultSchema();
+  const current = loadDepotNotesSchema();
+  saveDepotNotesSchema({
+    sections: current.sections,
+    checklist: defaults.checklist
   });
-
-  return cleaned;
+  refreshForm();
 }
 
-function normaliseSectionOrder(order) {
-  if (!Array.isArray(order)) return [];
-  const normalised = [];
-  const seen = new Set();
-  order.forEach((name) => {
-    const trimmed = typeof name === "string" ? name.trim() : String(name || "").trim();
-    if (!trimmed || seen.has(trimmed)) return;
-    seen.add(trimmed);
-    normalised.push(trimmed);
-  });
-  return normalised;
-}
-
-function normaliseChecklistConfigSource(raw) {
-  const base = {
-    sectionsOrder: [],
-    items: []
-  };
-
-  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
-    base.sectionsOrder = normaliseSectionOrder(raw.sectionsOrder);
-    base.items = sanitiseChecklistArray(raw.items);
-    return base;
-  }
-
-  base.items = sanitiseChecklistArray(raw);
-  return base;
-}
-
-async function loadChecklistConfig() {
-  let defaultConfig = { sectionsOrder: [], items: [] };
-  try {
-    const res = await fetch(CHECKLIST_CONFIG_URL, { cache: "no-store" });
-    if (res.ok) {
-      const data = await res.json();
-      defaultConfig = normaliseChecklistConfigSource(data);
-    }
-  } catch (err) {
-    console.warn("Failed to fetch default checklist", err);
-  }
-
-  let local = null;
-  try {
-    const raw = localStorage.getItem(CHECKLIST_STORAGE_KEY);
-    if (raw) {
-      local = JSON.parse(raw);
-    }
-  } catch (err) {
-    console.warn("Failed to read checklist override", err);
-  }
-
-  const candidate = normaliseChecklistConfigSource(local);
-  if (candidate.items.length) {
-    return candidate;
-  }
-
-  return defaultConfig;
-}
-
-function saveLocalChecklistConfig(value) {
-  const config = normaliseChecklistConfigSource(value);
-  try {
-    localStorage.setItem(CHECKLIST_STORAGE_KEY, JSON.stringify(config));
-  } catch (err) {
-    alert("Unable to save checklist: " + (err?.message || err));
-  }
-  return config;
+function shouldClearKey(key) {
+  return /^(depot[.-]|surveyBrain)/.test(key || "");
 }
 
 function clearLocalDepotStorage() {
-  const knownKeys = [
-    SECTION_STORAGE_KEY,
-    LEGACY_SECTION_STORAGE_KEY,
-    CHECKLIST_STORAGE_KEY,
-    AUTOSAVE_STORAGE_KEY,
-    LEGACY_SCHEMA_STORAGE_KEY,
-    CHECKLIST_STATE_STORAGE_KEY,
-    ...WORKER_ENDPOINT_STORAGE_KEYS
-  ];
-  try {
-    knownKeys.forEach((key) => {
-      if (!key) return;
-      try {
-        localStorage.removeItem(key);
-      } catch (_) {
-        // ignore storage issues per key
-      }
-    });
-  } catch (_) {
-    // ignore if localStorage is inaccessible entirely
-  }
-
-  const shouldClear = (key) => /^(depot[.-]|surveyBrain)/.test(key || "");
+  const keysToClear = new Set([
+    DEPOT_NOTES_SCHEMA_STORAGE_KEY,
+    ...LEGACY_STORAGE_KEYS,
+    ...WORKER_ENDPOINT_STORAGE_KEYS,
+    "depot-checklist-state"
+  ]);
+  keysToClear.forEach((key) => {
+    if (!key) return;
+    try {
+      localStorage.removeItem(key);
+    } catch (_) {
+      // ignore
+    }
+  });
 
   try {
-    const keys = [];
+    const extraKeys = [];
     for (let i = 0; i < localStorage.length; i += 1) {
       const key = localStorage.key(i);
-      if (key && shouldClear(key) && !knownKeys.includes(key)) {
-        keys.push(key);
+      if (key && shouldClearKey(key) && !keysToClear.has(key)) {
+        extraKeys.push(key);
       }
     }
-    keys.forEach((key) => {
+    extraKeys.forEach((key) => {
       try {
         localStorage.removeItem(key);
       } catch (_) {
@@ -287,7 +206,7 @@ function clearLocalDepotStorage() {
     const sessionKeys = [];
     for (let i = 0; i < sessionStorage.length; i += 1) {
       const key = sessionStorage.key(i);
-      if (key && shouldClear(key)) {
+      if (key && shouldClearKey(key)) {
         sessionKeys.push(key);
       }
     }
@@ -295,17 +214,17 @@ function clearLocalDepotStorage() {
       try {
         sessionStorage.removeItem(key);
       } catch (_) {
-        // ignore session storage issues
+        // ignore
       }
     });
   } catch (_) {
-    // ignore if sessionStorage unavailable
+    // ignore if sessionStorage inaccessible
   }
 
   try {
     clearWorkerEndpointOverride();
   } catch (_) {
-    // ignore inability to clear worker override
+    // ignore
   }
 }
 
@@ -313,11 +232,7 @@ async function unregisterServiceWorkers() {
   if (!("serviceWorker" in navigator)) return;
   try {
     const registrations = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(
-      registrations.map((registration) =>
-        registration.unregister().catch(() => false)
-      )
-    );
+    await Promise.all(registrations.map((registration) => registration.unregister().catch(() => false)));
   } catch (err) {
     console.warn("Failed to unregister service workers", err);
   }
@@ -356,592 +271,20 @@ async function forceReloadApp(button) {
   window.location.reload();
 }
 
-let editableSchema = [];
-let schemaArea;
-let sectionEditor;
-let checklistArea;
-let checklistEditor;
-let editableChecklist = [];
-let cachedSectionSchema = [];
-let cachedChecklistOrder = [];
-
-function ensureFuturePresence() {
-  let idx = editableSchema.findIndex((entry) => entry.name === FUTURE_PLANS_NAME);
-  if (idx === -1) {
-    editableSchema.push({ name: FUTURE_PLANS_NAME, description: "" });
-    idx = editableSchema.length - 1;
-  } else if (!editableSchema[idx].description) {
-    editableSchema[idx].description = "";
-  }
-  if (idx !== editableSchema.length - 1) {
-    const [future] = editableSchema.splice(idx, 1);
-    editableSchema.push(future);
-  }
+if (saveSchemaBtn) {
+  saveSchemaBtn.addEventListener("click", handleSaveSections);
+}
+if (resetSchemaBtn) {
+  resetSchemaBtn.addEventListener("click", handleResetSections);
+}
+if (saveChecklistBtn) {
+  saveChecklistBtn.addEventListener("click", handleSaveChecklist);
+}
+if (resetChecklistBtn) {
+  resetChecklistBtn.addEventListener("click", handleResetChecklist);
+}
+if (forceReloadBtn) {
+  forceReloadBtn.addEventListener("click", () => forceReloadApp(forceReloadBtn));
 }
 
-function updateSchemaTextarea() {
-  if (!schemaArea) return;
-  ensureFuturePresence();
-  const preview = editableSchema.map((entry, idx) => ({
-    name: entry.name || "",
-    description: entry.description || "",
-    order: idx + 1
-  }));
-  schemaArea.value = JSON.stringify(preview, null, 2);
-}
-
-function renderSectionEditor() {
-  if (!sectionEditor) return;
-  ensureFuturePresence();
-  sectionEditor.innerHTML = "";
-
-  editableSchema.forEach((entry, idx) => {
-    const row = document.createElement("div");
-    row.className = "section-row";
-
-    const fields = document.createElement("div");
-    fields.className = "section-fields";
-
-    const nameInput = document.createElement("input");
-    nameInput.type = "text";
-    nameInput.placeholder = "Section name";
-    nameInput.value = entry.name || "";
-    nameInput.disabled = entry.name === FUTURE_PLANS_NAME;
-    nameInput.addEventListener("input", (e) => {
-      editableSchema[idx].name = e.target.value;
-      updateSchemaTextarea();
-    });
-
-    const descInput = document.createElement("textarea");
-    descInput.placeholder = "Description (optional)";
-    descInput.value = entry.description || "";
-    descInput.rows = 2;
-    descInput.addEventListener("input", (e) => {
-      editableSchema[idx].description = e.target.value;
-      updateSchemaTextarea();
-    });
-
-    fields.appendChild(nameInput);
-    fields.appendChild(descInput);
-
-    const controls = document.createElement("div");
-    controls.className = "section-controls";
-
-    const upBtn = document.createElement("button");
-    upBtn.type = "button";
-    upBtn.textContent = "↑";
-    upBtn.disabled = idx === 0 || entry.name === FUTURE_PLANS_NAME;
-    upBtn.addEventListener("click", () => {
-      if (idx === 0) return;
-      const [item] = editableSchema.splice(idx, 1);
-      editableSchema.splice(idx - 1, 0, item);
-      renderSectionEditor();
-      updateSchemaTextarea();
-    });
-
-    const downBtn = document.createElement("button");
-    downBtn.type = "button";
-    downBtn.textContent = "↓";
-    downBtn.disabled = idx === editableSchema.length - 1 || entry.name === FUTURE_PLANS_NAME;
-    downBtn.addEventListener("click", () => {
-      if (idx >= editableSchema.length - 1) return;
-      const [item] = editableSchema.splice(idx, 1);
-      editableSchema.splice(idx + 1, 0, item);
-      renderSectionEditor();
-      updateSchemaTextarea();
-    });
-
-    const deleteBtn = document.createElement("button");
-    deleteBtn.type = "button";
-    deleteBtn.textContent = "Delete";
-    deleteBtn.disabled = entry.name === FUTURE_PLANS_NAME;
-    deleteBtn.addEventListener("click", () => {
-      editableSchema.splice(idx, 1);
-      renderSectionEditor();
-      updateSchemaTextarea();
-    });
-
-    controls.appendChild(upBtn);
-    controls.appendChild(downBtn);
-    controls.appendChild(deleteBtn);
-
-    row.appendChild(fields);
-    row.appendChild(controls);
-
-    sectionEditor.appendChild(row);
-  });
-
-  const addRow = document.createElement("div");
-  addRow.className = "section-add-row";
-  const addBtn = document.createElement("button");
-  addBtn.type = "button";
-  addBtn.textContent = "Add section";
-  addBtn.addEventListener("click", () => {
-    ensureFuturePresence();
-    const futureIndex = editableSchema.findIndex((entry) => entry.name === FUTURE_PLANS_NAME);
-    const insertIndex = futureIndex === -1 ? editableSchema.length : futureIndex;
-    editableSchema.splice(insertIndex, 0, { name: "", description: "" });
-    renderSectionEditor();
-    updateSchemaTextarea();
-  });
-  addRow.appendChild(addBtn);
-  sectionEditor.appendChild(addRow);
-}
-
-function getSectionNames() {
-  return cachedSectionSchema
-    .map((entry) => (entry && typeof entry.name === "string" ? entry.name.trim() : ""))
-    .filter(Boolean);
-}
-
-function applyChecklistOrder(orderCandidate) {
-  const schemaNames = getSectionNames();
-  const candidate = normaliseSectionOrder(orderCandidate);
-  const seen = new Set();
-  const order = [];
-
-  schemaNames.forEach((name) => {
-    if (candidate.includes(name) && !seen.has(name)) {
-      order.push(name);
-      seen.add(name);
-    }
-  });
-
-  candidate.forEach((name) => {
-    if (!seen.has(name) && !schemaNames.includes(name)) {
-      order.push(name);
-      seen.add(name);
-    }
-  });
-
-  schemaNames.forEach((name) => {
-    if (!seen.has(name)) {
-      order.push(name);
-      seen.add(name);
-    }
-  });
-
-  cachedChecklistOrder = order;
-}
-
-function setEditableChecklistFromRaw(rawItems) {
-  const sectionNames = getSectionNames();
-  const fallbackSection = sectionNames[0] || "";
-  const cleaned = sanitiseChecklistArray(rawItems);
-
-  editableChecklist = cleaned.map((item) => {
-    const extras = { ...item };
-    let section = extras.section && typeof extras.section === "string" ? extras.section.trim() : "";
-    if (!section && extras.depotSection && typeof extras.depotSection === "string") {
-      section = extras.depotSection.trim();
-    }
-    if (!section) {
-      section = fallbackSection;
-    }
-    extras.section = section;
-    if (section) {
-      extras.depotSection = section;
-    }
-    return {
-      id: extras.id,
-      group: extras.group || "",
-      section,
-      label: extras.label,
-      hint: extras.hint || "",
-      _extra: extras
-    };
-  });
-}
-
-function getEditableChecklistSnapshot() {
-  return editableChecklist.map((entry) => {
-    if (entry && entry._extra) {
-      return { ...entry._extra };
-    }
-    const section = entry && entry.section ? entry.section : "";
-    return {
-      id: entry?.id || "",
-      group: entry?.group || "",
-      section,
-      depotSection: section || undefined,
-      label: entry?.label || "",
-      hint: entry?.hint || "",
-      plainText: entry?.plainText || "",
-      naturalLanguage: entry?.naturalLanguage || "",
-      materials: Array.isArray(entry?.materials) ? entry.materials : []
-    };
-  });
-}
-
-function updateChecklistTextarea(items) {
-  if (!checklistArea) return;
-  const payloadSource = Array.isArray(items) ? items : getEditableChecklistSnapshot();
-  const payloadItems = sanitiseChecklistArray(payloadSource);
-  applyChecklistOrder(cachedChecklistOrder);
-  const order = cachedChecklistOrder.slice();
-  const payload = {
-    sectionsOrder: order,
-    items: payloadItems
-  };
-  checklistArea.value = JSON.stringify(payload, null, 2);
-}
-
-function readChecklistEditorState() {
-  if (!checklistEditor) return [];
-  const cards = Array.from(checklistEditor.querySelectorAll(".checklist-card"));
-  const items = [];
-
-  cards.forEach((card) => {
-    const index = Number(card.dataset.index ?? "-1");
-    const base = editableChecklist[index] && editableChecklist[index]._extra
-      ? { ...editableChecklist[index]._extra }
-      : {};
-
-    const idInput = card.querySelector(".checklist-input-id");
-    const labelInput = card.querySelector(".checklist-input-label");
-    if (!idInput || !labelInput) return;
-
-    const id = idInput.value.trim();
-    const label = labelInput.value.trim();
-    if (!id || !label) return;
-
-    const groupInput = card.querySelector(".checklist-input-group");
-    const sectionSelect = card.querySelector(".checklist-input-section");
-    const hintInput = card.querySelector(".checklist-input-hint");
-
-    const group = groupInput ? groupInput.value.trim() : "";
-    const section = sectionSelect ? sectionSelect.value.trim() : "";
-    const hint = hintInput ? hintInput.value.trim() : "";
-
-    const next = { ...base, id, group, label, hint };
-    next.section = section;
-    if (section) {
-      next.depotSection = section;
-    } else {
-      delete next.depotSection;
-    }
-    items.push(next);
-  });
-
-  return items;
-}
-
-function handleChecklistEditorChanged() {
-  const snapshot = readChecklistEditorState();
-  setEditableChecklistFromRaw(snapshot);
-  updateChecklistTextarea();
-}
-
-function drawChecklistEditor() {
-  if (!checklistEditor) return;
-  checklistEditor.innerHTML = "";
-
-  const sectionNames = getSectionNames();
-
-  editableChecklist.forEach((entry, idx) => {
-    const card = document.createElement("div");
-    card.className = "checklist-card";
-    card.dataset.index = String(idx);
-
-    const rowOne = document.createElement("div");
-    rowOne.className = "checklist-card-row";
-
-    const idLabel = document.createElement("label");
-    idLabel.textContent = "ID";
-    const idInput = document.createElement("input");
-    idInput.type = "text";
-    idInput.className = "checklist-input-id";
-    idInput.value = entry.id;
-    idInput.spellcheck = false;
-    idInput.addEventListener("input", handleChecklistEditorChanged);
-    idLabel.appendChild(idInput);
-    rowOne.appendChild(idLabel);
-
-    const groupLabel = document.createElement("label");
-    groupLabel.textContent = "Group";
-    const groupInput = document.createElement("input");
-    groupInput.type = "text";
-    groupInput.className = "checklist-input-group";
-    groupInput.value = entry.group || "";
-    groupInput.addEventListener("input", handleChecklistEditorChanged);
-    groupLabel.appendChild(groupInput);
-    rowOne.appendChild(groupLabel);
-
-    card.appendChild(rowOne);
-
-    const rowTwo = document.createElement("div");
-    rowTwo.className = "checklist-card-row";
-
-    const sectionLabel = document.createElement("label");
-    sectionLabel.textContent = "Section";
-    const sectionSelect = document.createElement("select");
-    sectionSelect.className = "checklist-input-section";
-
-    const blankOption = document.createElement("option");
-    blankOption.value = "";
-    blankOption.textContent = "Select section";
-    sectionSelect.appendChild(blankOption);
-
-    const seen = new Set();
-    sectionNames.forEach((name) => {
-      if (!name || seen.has(name)) return;
-      seen.add(name);
-      const option = document.createElement("option");
-      option.value = name;
-      option.textContent = name;
-      sectionSelect.appendChild(option);
-    });
-
-    if (entry.section && !seen.has(entry.section)) {
-      const option = document.createElement("option");
-      option.value = entry.section;
-      option.textContent = `${entry.section} (custom)`;
-      sectionSelect.appendChild(option);
-    }
-
-    sectionSelect.value = entry.section || "";
-    sectionSelect.addEventListener("change", handleChecklistEditorChanged);
-    sectionLabel.appendChild(sectionSelect);
-    rowTwo.appendChild(sectionLabel);
-
-    const labelLabel = document.createElement("label");
-    labelLabel.textContent = "Label";
-    const labelInput = document.createElement("input");
-    labelInput.type = "text";
-    labelInput.className = "checklist-input-label";
-    labelInput.value = entry.label || "";
-    labelInput.addEventListener("input", handleChecklistEditorChanged);
-    labelLabel.appendChild(labelInput);
-    rowTwo.appendChild(labelLabel);
-
-    card.appendChild(rowTwo);
-
-    const hintLabel = document.createElement("label");
-    hintLabel.textContent = "Hint";
-    const hintInput = document.createElement("textarea");
-    hintInput.className = "checklist-input-hint";
-    hintInput.value = entry.hint || "";
-    hintInput.addEventListener("input", handleChecklistEditorChanged);
-    hintLabel.appendChild(hintInput);
-    card.appendChild(hintLabel);
-
-    const actions = document.createElement("div");
-    actions.className = "checklist-card-actions";
-
-    const upBtn = document.createElement("button");
-    upBtn.type = "button";
-    upBtn.textContent = "↑";
-    upBtn.disabled = idx === 0;
-    upBtn.addEventListener("click", () => {
-      const snapshot = readChecklistEditorState();
-      if (idx <= 0) return;
-      const [item] = snapshot.splice(idx, 1);
-      snapshot.splice(idx - 1, 0, item);
-      setEditableChecklistFromRaw(snapshot);
-      drawChecklistEditor();
-      updateChecklistTextarea();
-    });
-
-    const downBtn = document.createElement("button");
-    downBtn.type = "button";
-    downBtn.textContent = "↓";
-    downBtn.disabled = idx === editableChecklist.length - 1;
-    downBtn.addEventListener("click", () => {
-      const snapshot = readChecklistEditorState();
-      if (idx >= snapshot.length - 1) return;
-      const [item] = snapshot.splice(idx, 1);
-      snapshot.splice(idx + 1, 0, item);
-      setEditableChecklistFromRaw(snapshot);
-      drawChecklistEditor();
-      updateChecklistTextarea();
-    });
-
-    const deleteBtn = document.createElement("button");
-    deleteBtn.type = "button";
-    deleteBtn.textContent = "Delete";
-    deleteBtn.className = "danger";
-    deleteBtn.addEventListener("click", () => {
-      const snapshot = readChecklistEditorState();
-      snapshot.splice(idx, 1);
-      setEditableChecklistFromRaw(snapshot);
-      drawChecklistEditor();
-      updateChecklistTextarea();
-    });
-
-    actions.appendChild(upBtn);
-    actions.appendChild(downBtn);
-    actions.appendChild(deleteBtn);
-
-    card.appendChild(actions);
-
-    checklistEditor.appendChild(card);
-  });
-
-  const addRow = document.createElement("div");
-  addRow.className = "checklist-add-row";
-  const addBtn = document.createElement("button");
-  addBtn.type = "button";
-  addBtn.textContent = "Add item";
-  addBtn.addEventListener("click", () => {
-    const snapshot = readChecklistEditorState();
-    const sectionNames = getSectionNames();
-    const fallback = sectionNames[0] || "";
-    const newId = `item_${Date.now()}`;
-    const base = {
-      id: newId,
-      group: "",
-      label: "New item",
-      hint: "",
-      section: fallback,
-      depotSection: fallback,
-      plainText: "",
-      naturalLanguage: "",
-      materials: []
-    };
-    snapshot.push(base);
-    setEditableChecklistFromRaw(snapshot);
-    drawChecklistEditor();
-    updateChecklistTextarea();
-  });
-  addRow.appendChild(addBtn);
-  checklistEditor.appendChild(addRow);
-}
-
-function renderChecklistEditor(config, sectionSchema) {
-  if (Array.isArray(sectionSchema)) {
-    cachedSectionSchema = sectionSchema.filter((entry) => entry && entry.name);
-  }
-
-  let items = [];
-  if (config && typeof config === "object" && !Array.isArray(config)) {
-    if (Array.isArray(config.items)) {
-      items = config.items;
-    }
-    applyChecklistOrder(config.sectionsOrder);
-  } else if (Array.isArray(config)) {
-    items = config;
-    applyChecklistOrder(cachedChecklistOrder);
-  } else {
-    applyChecklistOrder(cachedChecklistOrder);
-  }
-
-  setEditableChecklistFromRaw(items);
-  drawChecklistEditor();
-}
-
-async function initSettingsPage() {
-  checklistArea = document.getElementById("settings-checklist-json");
-  schemaArea = document.getElementById("settings-schema-json");
-  sectionEditor = document.getElementById("settings-section-editor");
-  checklistEditor = document.getElementById("checklist-editor");
-  const forceReloadBtn = document.getElementById("btn-force-reload");
-
-  if (!checklistArea || !schemaArea || !sectionEditor || !checklistEditor) {
-    console.warn("Settings elements missing");
-    return;
-  }
-
-  const [schema, checklist] = await Promise.all([
-    loadSectionSchema(),
-    loadChecklistConfig()
-  ]);
-
-  cachedSectionSchema = schema.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-  editableSchema = cachedSectionSchema.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-  renderSectionEditor();
-  updateSchemaTextarea();
-
-  renderChecklistEditor(checklist, cachedSectionSchema);
-  updateChecklistTextarea();
-
-  document.getElementById("btn-save-schema")?.addEventListener("click", () => {
-    try {
-      const final = saveLocalSectionSchema(editableSchema);
-      editableSchema = final.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-      cachedSectionSchema = editableSchema.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-      renderSectionEditor();
-      schemaArea.value = JSON.stringify(final, null, 2);
-      const snapshot = readChecklistEditorState();
-      renderChecklistEditor(snapshot, cachedSectionSchema);
-      updateChecklistTextarea();
-      alert("Output schema saved (local to this device).");
-    } catch (err) {
-      alert("Schema save failed: " + (err?.message || err));
-    }
-  });
-
-  document.getElementById("btn-reset-schema")?.addEventListener("click", async () => {
-    localStorage.removeItem(SECTION_STORAGE_KEY);
-    localStorage.removeItem(LEGACY_SECTION_STORAGE_KEY);
-    const fresh = await loadSectionSchema();
-    editableSchema = fresh.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-    cachedSectionSchema = editableSchema.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-    renderSectionEditor();
-    schemaArea.value = JSON.stringify(fresh, null, 2);
-    const snapshot = readChecklistEditorState();
-    renderChecklistEditor(snapshot, cachedSectionSchema);
-    updateChecklistTextarea();
-    alert("Schema reset to defaults.");
-  });
-
-  schemaArea.addEventListener("change", () => {
-    try {
-      const parsed = JSON.parse(schemaArea.value);
-      const sanitised = sanitiseSectionSchema(parsed);
-      editableSchema = sanitised.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-      cachedSectionSchema = editableSchema.map((entry) => ({ name: entry.name, description: entry.description || "" }));
-      renderSectionEditor();
-      updateSchemaTextarea();
-      const snapshot = readChecklistEditorState();
-      renderChecklistEditor(snapshot, cachedSectionSchema);
-      updateChecklistTextarea();
-    } catch (err) {
-      alert("Schema JSON invalid: " + (err?.message || err));
-    }
-  });
-
-  checklistArea.addEventListener("change", () => {
-    try {
-      const parsed = JSON.parse(checklistArea.value);
-      const config = normaliseChecklistConfigSource(parsed);
-      applyChecklistOrder(config.sectionsOrder);
-      setEditableChecklistFromRaw(config.items);
-      drawChecklistEditor();
-      updateChecklistTextarea();
-    } catch (err) {
-      alert("Checklist JSON invalid: " + (err?.message || err));
-    }
-  });
-
-  document.getElementById("btn-save-checklist")?.addEventListener("click", () => {
-    try {
-      const parsed = JSON.parse(checklistArea.value);
-      const saved = saveLocalChecklistConfig(parsed);
-      applyChecklistOrder(saved.sectionsOrder);
-      setEditableChecklistFromRaw(saved.items);
-      drawChecklistEditor();
-      updateChecklistTextarea();
-      alert("Checklist config saved (local to this device).");
-    } catch (err) {
-      alert("Checklist JSON invalid: " + (err?.message || err));
-    }
-  });
-
-  document.getElementById("btn-reset-checklist")?.addEventListener("click", async () => {
-    localStorage.removeItem(CHECKLIST_STORAGE_KEY);
-    const fresh = await loadChecklistConfig();
-    renderChecklistEditor(fresh, cachedSectionSchema);
-    updateChecklistTextarea();
-    alert("Checklist reset to defaults.");
-  });
-
-  if (forceReloadBtn) {
-    forceReloadBtn.addEventListener("click", () => {
-      forceReloadApp(forceReloadBtn);
-    });
-  }
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-  initSettingsPage();
-});
+refreshForm();


### PR DESCRIPTION
## Summary
- centralise depot notes section and checklist data behind a single settings-backed schema
- update the front-end to load schema from settings, replace section merges, and export sections in canonical order without duplicates
- simplify the settings editor to edit the schema JSON directly and refresh summaries, while keeping clearing utilities
- dedupe checklist-driven note generation to avoid repeated bullets and placeholders

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691867b420a8832cae7e0434079cc78a)