### PR TITLE
Align default checklist order with fallback sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,22 +317,7 @@
     ];
 
     const DEFAULT_CHECKLIST_CONFIG = {
-      sectionsOrder: [
-        "Needs",
-        "Working at heights",
-        "System characteristics",
-        "Components that require assistance",
-        "Restrictions to work",
-        "External hazards",
-        "Delivery notes",
-        "Office notes",
-        "New boiler and controls",
-        "Flue",
-        "Pipe work",
-        "Disruption",
-        "Customer actions",
-        "Future plans"
-      ],
+      sectionsOrder: DEFAULT_DEPOT_SECTIONS.slice(),
       items: [
         {
           id: "system_type_recorded",


### PR DESCRIPTION
## Summary
- ensure the default checklist configuration reuses the fallback depot section list so both remain in sync

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187742b9fc832cb8bbb14fb9de7973)