### PR TITLE
Add placeholder JS scaffolding files

### DIFF
--- a/js/appState.js
+++ b/js/appState.js
@@ -1,0 +1,13 @@
+export const appState = {
+  transcript: "",
+  sections: {},
+  checklistStatus: {},
+  materials: [],
+};
+
+export function resetAppState() {
+  appState.transcript = "";
+  appState.sections = {};
+  appState.checklistStatus = {};
+  appState.materials = [];
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+import { loadSchema } from "./schema.js";
+import { setupUI } from "./ui.js";
+
+const schema = loadSchema();
+setupUI(schema, () => {});

--- a/js/schema.js
+++ b/js/schema.js
@@ -1,0 +1,18 @@
+export function getDefaultSchema() {
+  return {
+    sections: [],
+    checklist: { sectionsOrder: [], items: [] }
+  };
+}
+
+export function normaliseSchema(raw) {
+  return getDefaultSchema();
+}
+
+export function loadSchema() {
+  return getDefaultSchema();
+}
+
+export function saveSchema(schema) {
+  return schema;
+}

--- a/js/settingsPage.js
+++ b/js/settingsPage.js
@@ -1,0 +1,3 @@
+import { loadSchema, saveSchema, getDefaultSchema } from "./schema.js";
+
+console.log("Settings page placeholder");

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,3 @@
+export function setupUI(schema, onSendText) {
+  console.log("UI placeholder, schema:", schema);
+}

--- a/js/workerClient.js
+++ b/js/workerClient.js
@@ -1,0 +1,12 @@
+export async function analyseText(text, schema) {
+  return {
+    summary: "",
+    sections: {},
+    checklistHits: [],
+    materials: []
+  };
+}
+
+export function setWorkerUrl(url) {
+  // placeholder
+}


### PR DESCRIPTION
## Summary
- add initial JavaScript scaffolding files for schema, app state, worker client, UI, main entry, and settings page
- provide minimal placeholder exports to support future implementation

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69188ecd75b8832c9ec029c01c129294)