### PR TITLE
refactor: add schema engine and rebuild settings UI

### DIFF
--- a/js/schema.js
+++ b/js/schema.js
@@ -1,18 +1,329 @@
-export function getDefaultSchema() {
+// js/schema.js
+
+const SECTION_STORAGE_KEY = "depot.sectionSchema";
+const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
+const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
+const FUTURE_PLANS_NAME = "Future plans";
+const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
+
+// Optional unified key for future versions (not required by the app yet)
+const LS_SCHEMA_KEY = "depot.notesSchema.v1";
+
+function safeParse(json, fallback) {
+  try {
+    if (!json) return fallback;
+    return JSON.parse(json);
+  } catch (err) {
+    console.warn("Failed to parse JSON:", err);
+    return fallback;
+  }
+}
+
+function sanitiseSectionSchema(input) {
+  const asArray = (value) => {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === "object" && Array.isArray(value.sections)) {
+      return value.sections;
+    }
+    return [];
+  };
+
+  const rawEntries = asArray(input);
+  const prepared = [];
+  rawEntries.forEach((entry, idx) => {
+    if (!entry) return;
+    const rawName = entry.name ?? entry.section ?? entry.title ?? entry.heading;
+    const name = typeof rawName === "string" ? rawName.trim() : "";
+    if (!name || name.toLowerCase() === "arse_cover_notes") return;
+
+    const rawDescription = entry.description ?? entry.hint ?? "";
+    const description = typeof rawDescription === "string"
+      ? rawDescription.trim()
+      : String(rawDescription || "").trim();
+
+    const order = typeof entry.order === "number" ? entry.order : idx + 1;
+    prepared.push({ name, description, order, idx });
+  });
+
+  prepared.sort((a, b) => {
+    const aHasOrder = typeof a.order === "number";
+    const bHasOrder = typeof b.order === "number";
+    if (aHasOrder && bHasOrder && a.order !== b.order) {
+      return a.order - b.order;
+    }
+    if (aHasOrder && !bHasOrder) return -1;
+    if (!aHasOrder && bHasOrder) return 1;
+    return a.idx - b.idx;
+  });
+
+  const unique = [];
+  const seen = new Set();
+  prepared.forEach((entry) => {
+    if (seen.has(entry.name)) return;
+    seen.add(entry.name);
+    unique.push({
+      name: entry.name,
+      description: entry.description || "",
+      order: entry.order
+    });
+  });
+
+  // Ensure Future plans exists and is last
+  let withoutFuture = unique.filter((entry) => entry.name !== FUTURE_PLANS_NAME);
+  let future = unique.find((entry) => entry.name === FUTURE_PLANS_NAME);
+  if (!future) {
+    future = {
+      name: FUTURE_PLANS_NAME,
+      description: FUTURE_PLANS_DESCRIPTION,
+      order: withoutFuture.length + 1
+    };
+  } else if (!future.description) {
+    future = { ...future, description: FUTURE_PLANS_DESCRIPTION };
+  }
+
+  const final = [...withoutFuture, future].map((entry, idx) => ({
+    name: entry.name,
+    description: entry.description || "",
+    order: idx + 1
+  }));
+
+  return final;
+}
+
+// Checklist sanitation similar to index.html
+function sanitiseChecklistArray(value) {
+  const asArray = (input) => {
+    if (!input) return [];
+    if (Array.isArray(input)) return input;
+    if (input && typeof input === "object" && Array.isArray(input.items)) {
+      return input.items;
+    }
+    return [];
+  };
+
+  const entries = asArray(value);
+  const seen = new Set();
+  const cleaned = [];
+
+  entries.forEach((item) => {
+    if (!item) return;
+    const copy = { ...item };
+    const id = copy.id != null ? String(copy.id).trim() : "";
+    const label = copy.label != null ? String(copy.label).trim() : "";
+    if (!id || !label || seen.has(id)) return;
+    seen.add(id);
+    copy.id = id;
+    copy.label = label;
+    copy.group = copy.group != null ? String(copy.group).trim() : (copy.category ? String(copy.category).trim() : "Checklist");
+    copy.hint = copy.hint != null ? String(copy.hint).trim() : (copy.description ? String(copy.description).trim() : "");
+    const section = copy.section != null && String(copy.section).trim()
+      ? String(copy.section).trim()
+      : copy.depotSection != null && String(copy.depotSection).trim()
+        ? String(copy.depotSection).trim()
+        : "";
+    copy.section = section;
+    if (section) {
+      copy.depotSection = section;
+    }
+    cleaned.push(copy);
+  });
+
+  return cleaned;
+}
+
+// Load defaults from the JSON files in the repo
+async function loadDefaultSectionSchema() {
+  try {
+    const res = await fetch("depot.output.schema.json", { cache: "no-store" });
+    if (!res.ok) return [];
+    const json = await res.json();
+    return sanitiseSectionSchema(json);
+  } catch (err) {
+    console.warn("Failed to load default section schema", err);
+    return [];
+  }
+}
+
+async function loadDefaultChecklist() {
+  try {
+    const res = await fetch("checklist.config.json", { cache: "no-store" });
+    if (!res.ok) return [];
+    const json = await res.json();
+    return sanitiseChecklistArray(json);
+  } catch (err) {
+    console.warn("Failed to load default checklist", err);
+    return [];
+  }
+}
+
+// Read any overrides existing in localStorage (for backward compatibility)
+function readStoredSectionOverride() {
+  const keys = [SECTION_STORAGE_KEY, LEGACY_SECTION_STORAGE_KEY];
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      return safeParse(raw, null);
+    } catch (_) {
+      continue;
+    }
+  }
+  return null;
+}
+
+function readStoredChecklistOverride() {
+  try {
+    const raw = localStorage.getItem(CHECKLIST_STORAGE_KEY);
+    if (!raw) return null;
+    return safeParse(raw, null);
+  } catch (_) {
+    return null;
+  }
+}
+
+// Public API: getDefaultSchema, loadSchema, saveSchema
+
+export async function getDefaultSchema() {
+  const [sections, checklistItems] = await Promise.all([
+    loadDefaultSectionSchema(),
+    loadDefaultChecklist()
+  ]);
+
+  const cleanedSections = sanitiseSectionSchema(sections);
+  const cleanedItems = sanitiseChecklistArray(checklistItems);
+
+  const sectionNames = cleanedSections.map((s) => s.name);
+  const sectionsOrder = sectionNames.slice();
+
   return {
-    sections: [],
-    checklist: { sectionsOrder: [], items: [] }
+    sections: sectionNames,
+    checklist: {
+      sectionsOrder,
+      items: cleanedItems
+    }
   };
 }
 
-export function normaliseSchema(raw) {
-  return getDefaultSchema();
+// Normalise an arbitrary "raw" schema-like structure into our canonical shape
+export function normaliseSchema(raw, fallback) {
+  const base = fallback || { sections: [], checklist: { sectionsOrder: [], items: [] } };
+  if (!raw || typeof raw !== "object") return base;
+
+  // Normalise sections
+  let sections = [];
+  if (Array.isArray(raw.sections)) {
+    sections = raw.sections
+      .map((s) => {
+        if (typeof s === "string") return s.trim();
+        if (s && typeof s === "object") {
+          const n = s.name ?? s.section ?? s.title ?? s.heading;
+          return typeof n === "string" ? n.trim() : "";
+        }
+        return "";
+      })
+      .filter((s) => s && s.toLowerCase() !== "arse_cover_notes");
+  }
+
+  // Ensure Future plans exists and is last
+  sections = sections.filter((s) => s !== FUTURE_PLANS_NAME);
+  sections.push(FUTURE_PLANS_NAME);
+
+  // Normalise checklist
+  let checklist = raw.checklist;
+  if (!checklist || typeof checklist !== "object") {
+    checklist = {};
+  }
+  const items = sanitiseChecklistArray(checklist.items ?? checklist);
+  let sectionsOrder = Array.isArray(checklist.sectionsOrder)
+    ? checklist.sectionsOrder.map((x) => String(x || "").trim()).filter(Boolean)
+    : [];
+
+  const seen = new Set();
+  sectionsOrder = sectionsOrder.filter((name) => {
+    const trimmed = name.trim();
+    if (!trimmed || seen.has(trimmed) || !sections.includes(trimmed)) return false;
+    seen.add(trimmed);
+    return true;
+  });
+  sections.forEach((name) => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      sectionsOrder.push(name);
+    }
+  });
+
+  return {
+    sections,
+    checklist: {
+      sectionsOrder,
+      items
+    }
+  };
 }
 
-export function loadSchema() {
-  return getDefaultSchema();
+export async function loadSchema() {
+  // Try unified schema first
+  const rawUnified = safeParse(localStorage.getItem(LS_SCHEMA_KEY), null);
+
+  // Also pull existing overrides to keep backward compatibility
+  const sectionOverride = readStoredSectionOverride();
+  const checklistOverride = readStoredChecklistOverride();
+
+  const defaults = await getDefaultSchema();
+
+  // If we have a unified schema, start from that
+  if (rawUnified) {
+    const merged = normaliseSchema(rawUnified, defaults);
+    return merged;
+  }
+
+  // Otherwise build from overrides + defaults
+  const mergedFromOverrides = normaliseSchema({
+    sections: sectionOverride,
+    checklist: checklistOverride
+  }, defaults);
+
+  return mergedFromOverrides;
 }
 
 export function saveSchema(schema) {
-  return schema;
+  if (!schema || typeof schema !== "object") {
+    throw new Error("Invalid schema to save");
+  }
+
+  // Normalise against itself
+  const normalised = normaliseSchema(schema, { sections: [], checklist: { sectionsOrder: [], items: [] } });
+
+  // Persist unified schema
+  try {
+    localStorage.setItem(LS_SCHEMA_KEY, JSON.stringify(normalised));
+  } catch (err) {
+    console.warn("Failed to save unified depot schema", err);
+  }
+
+  // Also persist legacy keys for compatibility with the main app
+
+  // Sections format: an array of { name, description, order }
+  const legacySections = normalised.sections.map((name, idx) => ({
+    name,
+    description: name === FUTURE_PLANS_NAME ? FUTURE_PLANS_DESCRIPTION : "",
+    order: idx + 1
+  }));
+  try {
+    localStorage.setItem(SECTION_STORAGE_KEY, JSON.stringify(legacySections));
+  } catch (err) {
+    console.warn("Failed to save legacy section schema", err);
+  }
+
+  // Checklist format: array of items
+  const legacyChecklist = normalised.checklist.items;
+  try {
+    localStorage.setItem(CHECKLIST_STORAGE_KEY, JSON.stringify(legacyChecklist));
+  } catch (err) {
+    console.warn("Failed to save legacy checklist config", err);
+  }
+
+  return normalised;
 }

--- a/js/settingsPage.js
+++ b/js/settingsPage.js
@@ -1,3 +1,795 @@
 import { loadSchema, saveSchema, getDefaultSchema } from "./schema.js";
 
-console.log("Settings page placeholder");
+const FUTURE_PLANS_NAME = "Future plans";
+const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
+const SECTION_STORAGE_KEY = "depot.sectionSchema";
+const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
+const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
+const LS_SCHEMA_KEY = "depot.notesSchema.v1";
+const AUTOSAVE_STORAGE_KEY = "surveyBrainAutosave";
+const LEGACY_SCHEMA_STORAGE_KEY = "depot-output-schema";
+const CHECKLIST_STATE_STORAGE_KEY = "depot-checklist-state";
+const WORKER_ENDPOINT_STORAGE_KEYS = ["depot.workerUrl", "depot-worker-url"];
+
+const state = {
+  sections: [],
+  sectionsOrder: [],
+  checklistItems: []
+};
+
+let defaultSchema = { sections: [], checklist: { sectionsOrder: [], items: [] } };
+let pendingSectionFocusId = null;
+let pendingChecklistFocusId = null;
+let sectionIdCounter = 0;
+let checklistIdCounter = 0;
+
+const sectionEditor = document.getElementById("settings-section-editor");
+const checklistEditor = document.getElementById("checklist-editor");
+const schemaTextarea = document.getElementById("settings-schema-json");
+const checklistTextarea = document.getElementById("settings-checklist-json");
+const statusEl = document.getElementById("settings-status");
+
+const btnSaveSchema = document.getElementById("btn-save-schema");
+const btnResetSchema = document.getElementById("btn-reset-schema");
+const btnSaveChecklist = document.getElementById("btn-save-checklist");
+const btnResetChecklist = document.getElementById("btn-reset-checklist");
+const btnForceReload = document.getElementById("btn-force-reload");
+
+function nextSectionId() {
+  sectionIdCounter += 1;
+  return `section-${Date.now()}-${sectionIdCounter}`;
+}
+
+function nextChecklistId() {
+  checklistIdCounter += 1;
+  return `checklist-${Date.now()}-${checklistIdCounter}`;
+}
+
+function createSection(name, { locked = false } = {}) {
+  return {
+    id: nextSectionId(),
+    name: typeof name === "string" ? name : "",
+    locked
+  };
+}
+
+function ensureFutureSection() {
+  let future = state.sections.find((section) => section.name === FUTURE_PLANS_NAME);
+  state.sections = state.sections.filter((section) => section.name !== FUTURE_PLANS_NAME);
+  if (!future) {
+    future = createSection(FUTURE_PLANS_NAME, { locked: true });
+  } else {
+    future.locked = true;
+    future.name = FUTURE_PLANS_NAME;
+  }
+  state.sections.push(future);
+}
+
+function syncSectionsOrder() {
+  const trimmedSections = state.sections
+    .map((section) => section.name.trim())
+    .filter((name) => name && name.toLowerCase() !== "arse_cover_notes");
+
+  const seen = new Set();
+  const order = [];
+  state.sectionsOrder.forEach((entry) => {
+    const trimmed = typeof entry === "string" ? entry.trim() : String(entry || "").trim();
+    if (!trimmed || seen.has(trimmed) || !trimmedSections.includes(trimmed)) return;
+    seen.add(trimmed);
+    order.push(trimmed);
+  });
+  trimmedSections.forEach((name) => {
+    if (!seen.has(name)) {
+      seen.add(name);
+      order.push(name);
+    }
+  });
+  if (!seen.has(FUTURE_PLANS_NAME)) {
+    order.push(FUTURE_PLANS_NAME);
+  } else {
+    const filtered = order.filter((name) => name !== FUTURE_PLANS_NAME);
+    filtered.push(FUTURE_PLANS_NAME);
+    order.length = 0;
+    filtered.forEach((name) => order.push(name));
+  }
+  state.sectionsOrder = order;
+}
+
+function copyChecklistItem(item) {
+  const base = item ? { ...item } : {};
+  const copy = {
+    ...base,
+    internalId: base.internalId || nextChecklistId()
+  };
+  if (typeof copy._materialsText !== "string") {
+    const materials = Array.isArray(copy.materials) ? copy.materials : [];
+    copy._materialsText = JSON.stringify(materials, null, 2);
+  }
+  copy.group = copy.group != null ? String(copy.group) : "";
+  copy.hint = copy.hint != null ? String(copy.hint) : "";
+  copy.plainText = copy.plainText != null ? String(copy.plainText) : "";
+  copy.naturalLanguage = copy.naturalLanguage != null ? String(copy.naturalLanguage) : "";
+  copy.section = copy.section != null ? String(copy.section) : (copy.depotSection != null ? String(copy.depotSection) : "");
+  if (copy.section) {
+    copy.depotSection = copy.section;
+  }
+  return copy;
+}
+
+function applySchema(schema) {
+  const source = schema || { sections: [], checklist: { sectionsOrder: [], items: [] } };
+  state.sections = (source.sections || []).map((name) => {
+    const isFuture = name === FUTURE_PLANS_NAME;
+    return {
+      id: nextSectionId(),
+      name,
+      locked: isFuture
+    };
+  });
+  if (!state.sections.length) {
+    state.sections.push(createSection(FUTURE_PLANS_NAME, { locked: true }));
+  }
+  state.sectionsOrder = Array.isArray(source.checklist?.sectionsOrder)
+    ? source.checklist.sectionsOrder.slice()
+    : [];
+  state.checklistItems = Array.isArray(source.checklist?.items)
+    ? source.checklist.items.map((item) => copyChecklistItem(item))
+    : [];
+}
+
+function setStatus(message, tone = "info") {
+  if (!statusEl) return;
+  statusEl.textContent = message || "";
+  statusEl.className = "status";
+  if (tone === "success") {
+    statusEl.classList.add("status--success");
+  } else if (tone === "error") {
+    statusEl.classList.add("status--error");
+  } else if (tone === "muted") {
+    statusEl.classList.add("status--muted");
+  }
+}
+
+function buildSchemaFromState({ strict = true } = {}) {
+  const workingSections = state.sections.map((section) => ({ ...section }));
+  const workingOrder = Array.isArray(state.sectionsOrder)
+    ? state.sectionsOrder.slice()
+    : [];
+
+  const sectionNames = [];
+  const seenSections = new Set();
+  let hasFuture = false;
+  workingSections.forEach((section) => {
+    const trimmed = typeof section.name === "string" ? section.name.trim() : "";
+    if (!trimmed || trimmed.toLowerCase() === "arse_cover_notes") return;
+    if (trimmed === FUTURE_PLANS_NAME) {
+      hasFuture = true;
+      return;
+    }
+    if (seenSections.has(trimmed)) return;
+    seenSections.add(trimmed);
+    sectionNames.push(trimmed);
+  });
+  if (hasFuture || !sectionNames.includes(FUTURE_PLANS_NAME)) {
+    sectionNames.push(FUTURE_PLANS_NAME);
+  }
+
+  const order = [];
+  const seenOrder = new Set();
+  workingOrder.forEach((entry) => {
+    const trimmed = typeof entry === "string" ? entry.trim() : String(entry || "").trim();
+    if (!trimmed || seenOrder.has(trimmed) || !sectionNames.includes(trimmed)) return;
+    seenOrder.add(trimmed);
+    order.push(trimmed);
+  });
+  sectionNames.forEach((name) => {
+    if (!seenOrder.has(name)) {
+      seenOrder.add(name);
+      order.push(name);
+    }
+  });
+
+  const items = [];
+  state.checklistItems.forEach((item) => {
+    const copy = { ...item };
+    const id = copy.id != null ? String(copy.id).trim() : "";
+    const label = copy.label != null ? String(copy.label).trim() : "";
+    if (!id || !label) {
+      if (strict) {
+        throw new Error("Checklist items must include both an id and label");
+      }
+      return;
+    }
+    copy.id = id;
+    copy.label = label;
+    copy.group = copy.group != null ? String(copy.group).trim() : "";
+    copy.hint = copy.hint != null ? String(copy.hint).trim() : "";
+    copy.section = copy.section != null ? String(copy.section).trim() : "";
+    if (copy.section) {
+      copy.depotSection = copy.section;
+    } else {
+      delete copy.depotSection;
+    }
+    copy.plainText = copy.plainText != null ? String(copy.plainText).trim() : "";
+    copy.naturalLanguage = copy.naturalLanguage != null ? String(copy.naturalLanguage).trim() : "";
+
+    if (typeof copy._materialsText === "string") {
+      const text = copy._materialsText.trim();
+      if (!text) {
+        copy.materials = [];
+      } else {
+        try {
+          const parsed = JSON.parse(text);
+          copy.materials = Array.isArray(parsed) ? parsed : [];
+        } catch (err) {
+          if (strict) {
+            throw new Error(`Item "${id}" has invalid materials JSON: ${err.message}`);
+          }
+          copy.materials = Array.isArray(copy.materials) ? copy.materials : [];
+        }
+      }
+    }
+
+    delete copy.internalId;
+    delete copy._materialsText;
+    items.push(copy);
+  });
+
+  return {
+    sections,
+    checklist: {
+      sectionsOrder: order,
+      items
+    }
+  };
+}
+
+function updateJSONPreview() {
+  if (!schemaTextarea || !checklistTextarea) return;
+  try {
+    const schema = buildSchemaFromState({ strict: false });
+    const legacySections = schema.sections.map((name, idx) => ({
+      name,
+      description: name === FUTURE_PLANS_NAME ? FUTURE_PLANS_DESCRIPTION : "",
+      order: idx + 1
+    }));
+    schemaTextarea.value = JSON.stringify(legacySections, null, 2);
+    checklistTextarea.value = JSON.stringify(schema.checklist.items, null, 2);
+  } catch (err) {
+    schemaTextarea.value = "";
+    checklistTextarea.value = "";
+  }
+}
+
+function renderSectionEditor() {
+  if (!sectionEditor) return;
+  sectionEditor.innerHTML = "";
+
+  if (!state.sections.length) {
+    ensureFutureSection();
+  }
+
+  state.sections.forEach((section, idx) => {
+    const row = document.createElement("div");
+    row.className = "section-row";
+
+    const fields = document.createElement("div");
+    fields.className = "section-fields";
+
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.placeholder = "Section name";
+    nameInput.value = section.name;
+    nameInput.disabled = section.locked;
+    nameInput.dataset.sectionId = section.id;
+    nameInput.addEventListener("focus", () => {
+      nameInput.dataset.initialName = section.name;
+    });
+    nameInput.addEventListener("input", (event) => {
+      section.name = event.target.value;
+      updateJSONPreview();
+    });
+    nameInput.addEventListener("blur", (event) => {
+      const previous = (nameInput.dataset.initialName || "").trim();
+      const trimmed = event.target.value.trim();
+      section.name = trimmed;
+      if (previous && trimmed && previous !== trimmed) {
+        state.checklistItems.forEach((item) => {
+          if (item.section === previous) {
+            item.section = trimmed;
+            item.depotSection = trimmed;
+          }
+        });
+        state.sectionsOrder = state.sectionsOrder.map((entry) => (entry === previous ? trimmed : entry));
+      }
+      refreshUI();
+    });
+    fields.appendChild(nameInput);
+
+    const controls = document.createElement("div");
+    controls.className = "section-controls";
+
+    const upBtn = document.createElement("button");
+    upBtn.type = "button";
+    upBtn.textContent = "↑";
+    upBtn.disabled = idx === 0 || section.locked;
+    upBtn.addEventListener("click", () => {
+      if (idx === 0) return;
+      const [item] = state.sections.splice(idx, 1);
+      state.sections.splice(idx - 1, 0, item);
+      refreshUI();
+    });
+
+    const downBtn = document.createElement("button");
+    downBtn.type = "button";
+    downBtn.textContent = "↓";
+    downBtn.disabled = idx === state.sections.length - 1 || section.locked;
+    downBtn.addEventListener("click", () => {
+      if (idx >= state.sections.length - 1) return;
+      const [item] = state.sections.splice(idx, 1);
+      state.sections.splice(idx + 1, 0, item);
+      refreshUI();
+    });
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.disabled = section.locked;
+    deleteBtn.addEventListener("click", () => {
+      if (section.locked) return;
+      const trimmed = section.name.trim();
+      state.sections.splice(idx, 1);
+      state.sectionsOrder = state.sectionsOrder.filter((entry) => entry !== trimmed);
+      state.checklistItems.forEach((item) => {
+        if (item.section === trimmed) {
+          item.section = "";
+          item.depotSection = "";
+        }
+      });
+      refreshUI();
+    });
+
+    controls.appendChild(upBtn);
+    controls.appendChild(downBtn);
+    controls.appendChild(deleteBtn);
+
+    row.appendChild(fields);
+    row.appendChild(controls);
+    sectionEditor.appendChild(row);
+
+    if (pendingSectionFocusId && pendingSectionFocusId === section.id) {
+      setTimeout(() => {
+        nameInput.focus();
+        nameInput.select();
+      }, 0);
+    }
+  });
+
+  const addRow = document.createElement("div");
+  addRow.className = "section-add-row";
+  const addBtn = document.createElement("button");
+  addBtn.type = "button";
+  addBtn.textContent = "Add section";
+  addBtn.addEventListener("click", () => {
+    ensureFutureSection();
+    const insertIndex = Math.max(0, state.sections.length - 1);
+    const newSection = createSection("");
+    state.sections.splice(insertIndex, 0, newSection);
+    pendingSectionFocusId = newSection.id;
+    refreshUI();
+  });
+  addRow.appendChild(addBtn);
+  sectionEditor.appendChild(addRow);
+
+  pendingSectionFocusId = null;
+}
+
+function renderChecklistEditor() {
+  if (!checklistEditor) return;
+  checklistEditor.innerHTML = "";
+
+  if (!state.checklistItems.length) {
+    const empty = document.createElement("p");
+    empty.className = "hint";
+    empty.textContent = "No checklist items configured.";
+    checklistEditor.appendChild(empty);
+  }
+
+  const sectionOptions = state.sections
+    .map((section) => section.name.trim())
+    .filter((name, index, arr) => name && arr.indexOf(name) === index);
+
+  state.checklistItems.forEach((item, idx) => {
+    const card = document.createElement("div");
+    card.className = "checklist-card";
+
+    const rowOne = document.createElement("div");
+    rowOne.className = "checklist-card-row";
+
+    const idLabel = document.createElement("label");
+    idLabel.textContent = "ID";
+    const idInput = document.createElement("input");
+    idInput.type = "text";
+    idInput.value = item.id || "";
+    idInput.addEventListener("input", (event) => {
+      item.id = event.target.value;
+      updateJSONPreview();
+    });
+    idLabel.appendChild(idInput);
+    rowOne.appendChild(idLabel);
+
+    const groupLabel = document.createElement("label");
+    groupLabel.textContent = "Group";
+    const groupInput = document.createElement("input");
+    groupInput.type = "text";
+    groupInput.value = item.group || "";
+    groupInput.addEventListener("input", (event) => {
+      item.group = event.target.value;
+      updateJSONPreview();
+    });
+    groupLabel.appendChild(groupInput);
+    rowOne.appendChild(groupLabel);
+
+    card.appendChild(rowOne);
+
+    const rowTwo = document.createElement("div");
+    rowTwo.className = "checklist-card-row";
+
+    const sectionLabel = document.createElement("label");
+    sectionLabel.textContent = "Section";
+    const sectionSelect = document.createElement("select");
+    const blankOption = document.createElement("option");
+    blankOption.value = "";
+    blankOption.textContent = "Select section";
+    sectionSelect.appendChild(blankOption);
+
+    sectionOptions.forEach((name) => {
+      const option = document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      sectionSelect.appendChild(option);
+    });
+
+    if (item.section && !sectionOptions.includes(item.section)) {
+      const option = document.createElement("option");
+      option.value = item.section;
+      option.textContent = `${item.section} (custom)`;
+      sectionSelect.appendChild(option);
+    }
+
+    sectionSelect.value = item.section || "";
+    sectionSelect.addEventListener("change", (event) => {
+      item.section = event.target.value;
+      item.depotSection = event.target.value;
+      updateJSONPreview();
+    });
+    sectionLabel.appendChild(sectionSelect);
+    rowTwo.appendChild(sectionLabel);
+
+    const labelLabel = document.createElement("label");
+    labelLabel.textContent = "Label";
+    const labelInput = document.createElement("input");
+    labelInput.type = "text";
+    labelInput.value = item.label || "";
+    labelInput.addEventListener("input", (event) => {
+      item.label = event.target.value;
+      updateJSONPreview();
+    });
+    labelLabel.appendChild(labelInput);
+    rowTwo.appendChild(labelLabel);
+
+    card.appendChild(rowTwo);
+
+    const hintLabel = document.createElement("label");
+    hintLabel.textContent = "Hint";
+    const hintInput = document.createElement("textarea");
+    hintInput.value = item.hint || "";
+    hintInput.addEventListener("input", (event) => {
+      item.hint = event.target.value;
+      updateJSONPreview();
+    });
+    hintLabel.appendChild(hintInput);
+    card.appendChild(hintLabel);
+
+    const plainTextLabel = document.createElement("label");
+    plainTextLabel.textContent = "Plain text";
+    const plainTextInput = document.createElement("textarea");
+    plainTextInput.value = item.plainText || "";
+    plainTextInput.addEventListener("input", (event) => {
+      item.plainText = event.target.value;
+      updateJSONPreview();
+    });
+    plainTextLabel.appendChild(plainTextInput);
+    card.appendChild(plainTextLabel);
+
+    const naturalLabel = document.createElement("label");
+    naturalLabel.textContent = "Natural language";
+    const naturalInput = document.createElement("textarea");
+    naturalInput.value = item.naturalLanguage || "";
+    naturalInput.addEventListener("input", (event) => {
+      item.naturalLanguage = event.target.value;
+      updateJSONPreview();
+    });
+    naturalLabel.appendChild(naturalInput);
+    card.appendChild(naturalLabel);
+
+    const materialsLabel = document.createElement("label");
+    materialsLabel.textContent = "Materials (JSON)";
+    const materialsInput = document.createElement("textarea");
+    materialsInput.value = item._materialsText || "[]";
+    materialsInput.addEventListener("input", (event) => {
+      item._materialsText = event.target.value;
+      updateJSONPreview();
+    });
+    materialsLabel.appendChild(materialsInput);
+    card.appendChild(materialsLabel);
+
+    const actions = document.createElement("div");
+    actions.className = "checklist-card-actions";
+
+    const upBtn = document.createElement("button");
+    upBtn.type = "button";
+    upBtn.textContent = "↑";
+    upBtn.disabled = idx === 0;
+    upBtn.addEventListener("click", () => {
+      if (idx === 0) return;
+      const [itemToMove] = state.checklistItems.splice(idx, 1);
+      state.checklistItems.splice(idx - 1, 0, itemToMove);
+      refreshUI();
+    });
+    actions.appendChild(upBtn);
+
+    const downBtn = document.createElement("button");
+    downBtn.type = "button";
+    downBtn.textContent = "↓";
+    downBtn.disabled = idx === state.checklistItems.length - 1;
+    downBtn.addEventListener("click", () => {
+      if (idx >= state.checklistItems.length - 1) return;
+      const [itemToMove] = state.checklistItems.splice(idx, 1);
+      state.checklistItems.splice(idx + 1, 0, itemToMove);
+      refreshUI();
+    });
+    actions.appendChild(downBtn);
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.className = "danger";
+    deleteBtn.addEventListener("click", () => {
+      state.checklistItems.splice(idx, 1);
+      refreshUI();
+    });
+    actions.appendChild(deleteBtn);
+
+    card.appendChild(actions);
+    checklistEditor.appendChild(card);
+
+    if (pendingChecklistFocusId && pendingChecklistFocusId === item.internalId) {
+      setTimeout(() => {
+        idInput.focus();
+        idInput.select();
+      }, 0);
+    }
+  });
+
+  const addRow = document.createElement("div");
+  addRow.className = "checklist-add-row";
+  const addBtn = document.createElement("button");
+  addBtn.type = "button";
+  addBtn.textContent = "Add item";
+  addBtn.addEventListener("click", () => {
+    const fallbackSection = state.sections
+      .map((section) => section.name.trim())
+      .find((name) => name && name !== FUTURE_PLANS_NAME) || "";
+    const newItem = copyChecklistItem({
+      id: `item_${Date.now()}`,
+      label: "",
+      group: "",
+      hint: "",
+      section: fallbackSection,
+      depotSection: fallbackSection,
+      plainText: "",
+      naturalLanguage: "",
+      materials: []
+    });
+    state.checklistItems.push(newItem);
+    pendingChecklistFocusId = newItem.internalId;
+    refreshUI();
+  });
+  addRow.appendChild(addBtn);
+  checklistEditor.appendChild(addRow);
+
+  pendingChecklistFocusId = null;
+}
+
+function refreshUI() {
+  ensureFutureSection();
+  syncSectionsOrder();
+  renderSectionEditor();
+  renderChecklistEditor();
+  updateJSONPreview();
+}
+
+function handleSave() {
+  try {
+    const prepared = buildSchemaFromState({ strict: true });
+    const saved = saveSchema(prepared);
+    applySchema(saved);
+    refreshUI();
+    setStatus("Saved to this browser.", "success");
+  } catch (err) {
+    console.error(err);
+    setStatus(err?.message || "Failed to save settings.", "error");
+  }
+}
+
+function handleResetSections() {
+  if (!defaultSchema || !defaultSchema.sections) return;
+  state.sections = defaultSchema.sections.map((name) => createSection(name, { locked: name === FUTURE_PLANS_NAME }));
+  state.sectionsOrder = defaultSchema.checklist.sectionsOrder.slice();
+  const validNames = new Set(state.sections.map((section) => section.name.trim()).filter(Boolean));
+  state.checklistItems.forEach((item) => {
+    if (item.section && !validNames.has(item.section)) {
+      item.section = "";
+      item.depotSection = "";
+    }
+  });
+  refreshUI();
+  setStatus("Sections reset to defaults.", "muted");
+}
+
+function handleResetChecklist() {
+  if (!defaultSchema || !defaultSchema.checklist) return;
+  const clone = defaultSchema.checklist.items.map((item) => copyChecklistItem(item));
+  state.checklistItems = clone;
+  state.sectionsOrder = defaultSchema.checklist.sectionsOrder.slice();
+  refreshUI();
+  setStatus("Checklist reset to defaults.", "muted");
+}
+
+function clearLocalDepotStorage() {
+  const knownKeys = [
+    SECTION_STORAGE_KEY,
+    LEGACY_SECTION_STORAGE_KEY,
+    CHECKLIST_STORAGE_KEY,
+    LS_SCHEMA_KEY,
+    AUTOSAVE_STORAGE_KEY,
+    LEGACY_SCHEMA_STORAGE_KEY,
+    CHECKLIST_STATE_STORAGE_KEY,
+    ...WORKER_ENDPOINT_STORAGE_KEYS
+  ];
+  try {
+    knownKeys.forEach((key) => {
+      if (!key) return;
+      try {
+        localStorage.removeItem(key);
+      } catch (_) {
+        // ignore per-key failures
+      }
+    });
+  } catch (_) {
+    // ignore inability to access localStorage
+  }
+
+  const shouldClear = (key) => /^(depot[.-]|surveyBrain)/.test(key || "");
+
+  try {
+    const extraKeys = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key && shouldClear(key) && !knownKeys.includes(key)) {
+        extraKeys.push(key);
+      }
+    }
+    extraKeys.forEach((key) => {
+      try {
+        localStorage.removeItem(key);
+      } catch (_) {
+        // ignore
+      }
+    });
+  } catch (_) {
+    // ignore inability to enumerate localStorage
+  }
+
+  try {
+    const sessionKeys = [];
+    for (let i = 0; i < sessionStorage.length; i += 1) {
+      const key = sessionStorage.key(i);
+      if (key && shouldClear(key)) {
+        sessionKeys.push(key);
+      }
+    }
+    sessionKeys.forEach((key) => {
+      try {
+        sessionStorage.removeItem(key);
+      } catch (_) {
+        // ignore
+      }
+    });
+  } catch (_) {
+    // ignore sessionStorage access issues
+  }
+}
+
+async function unregisterServiceWorkers() {
+  if (!("serviceWorker" in navigator)) return;
+  try {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((registration) => registration.unregister().catch(() => false)));
+  } catch (err) {
+    console.warn("Failed to unregister service workers", err);
+  }
+}
+
+async function clearAppCaches() {
+  if (typeof window === "undefined" || !("caches" in window)) return;
+  try {
+    const keys = await caches.keys();
+    await Promise.all(keys.map((key) => caches.delete(key).catch(() => false)));
+  } catch (err) {
+    console.warn("Failed to clear caches", err);
+  }
+}
+
+async function handleForceReload(event) {
+  const confirmation = window.confirm(
+    "This will clear Depot overrides on this device and reload. Continue?"
+  );
+  if (!confirmation) return;
+
+  const button = event?.currentTarget || null;
+  if (button) {
+    button.disabled = true;
+    button.textContent = "Clearing…";
+  }
+
+  clearLocalDepotStorage();
+  await unregisterServiceWorkers();
+  await clearAppCaches();
+
+  if (button) {
+    button.textContent = "Reloading…";
+  }
+
+  window.location.reload();
+}
+
+async function init() {
+  setStatus("Loading settings…", "muted");
+  try {
+    const [defaults, loaded] = await Promise.all([
+      getDefaultSchema(),
+      loadSchema()
+    ]);
+    defaultSchema = defaults;
+    applySchema(loaded);
+    refreshUI();
+    setStatus("Loaded. Changes are stored locally in this browser.");
+  } catch (err) {
+    console.error(err);
+    setStatus("Failed to load schema information.", "error");
+  }
+}
+
+if (btnSaveSchema) {
+  btnSaveSchema.addEventListener("click", handleSave);
+}
+if (btnSaveChecklist) {
+  btnSaveChecklist.addEventListener("click", handleSave);
+}
+if (btnResetSchema) {
+  btnResetSchema.addEventListener("click", handleResetSections);
+}
+if (btnResetChecklist) {
+  btnResetChecklist.addEventListener("click", handleResetChecklist);
+}
+if (btnForceReload) {
+  btnForceReload.addEventListener("click", handleForceReload);
+}
+
+if (document.readyState === "loading") {
+  window.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/settings.html
+++ b/settings.html
@@ -108,6 +108,24 @@
       font-size: 0.8rem;
       color: var(--muted);
     }
+    .status {
+      margin-top: -8px;
+      font-size: 0.85rem;
+      color: var(--muted);
+      min-height: 1.2em;
+    }
+    .status--success {
+      color: var(--accent);
+    }
+    .status--error {
+      color: var(--danger);
+    }
+    .status--muted {
+      color: var(--muted);
+    }
+    textarea[readonly] {
+      background: #f1f5f9;
+    }
     a.back-link {
       font-size: 0.8rem;
       color: var(--accent);
@@ -263,11 +281,12 @@
   <main>
     <a class="back-link" href="index.html">← Back to notes</a>
     <h1>Depot Settings</h1>
+    <div id="settings-status" class="status" aria-live="polite"></div>
     <section>
       <h2>Checklist configuration</h2>
       <p>Edit the mapping from checklist ticks to Depot notes &amp; materials. Changes are stored locally on this device.</p>
       <div id="checklist-editor" class="checklist-editor"></div>
-      <textarea id="settings-checklist-json"></textarea>
+      <textarea id="settings-checklist-json" readonly></textarea>
       <div class="btn-row">
         <button id="btn-save-checklist">Save (this device)</button>
         <button id="btn-reset-checklist" class="secondary">Reset to defaults</button>
@@ -277,7 +296,7 @@
       <h2>Depot output schema</h2>
       <p>Control Depot section names and ordering. Overrides apply locally until cleared.</p>
       <div id="settings-section-editor" class="section-editor"></div>
-      <textarea id="settings-schema-json"></textarea>
+      <textarea id="settings-schema-json" readonly></textarea>
       <div class="btn-row">
         <button id="btn-save-schema">Save (this device)</button>
         <button id="btn-reset-schema" class="secondary">Reset to defaults</button>
@@ -291,6 +310,6 @@
       </div>
     </section>
   </main>
-  <script type="module" src="./src/settings/settings.js"></script>
+  <script type="module" src="./js/settingsPage.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement a real schema engine that normalises section and checklist overrides while keeping legacy storage keys in sync
- rebuild the settings page UI to edit sections and checklist items with live previews and local-only persistence
- add utilities to reset overrides, clear local storage, and force reload matching the main app expectations

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189eeda5f4832c951b6592d7de58ee)