### PR TITLE
feat: rebuild settings page for schema editing

### DIFF
--- a/js/settingsPage.js
+++ b/js/settingsPage.js
@@ -1,140 +1,41 @@
 import { loadSchema, saveSchema, getDefaultSchema } from "./schema.js";
 
 const FUTURE_PLANS_NAME = "Future plans";
-const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
-const SECTION_STORAGE_KEY = "depot.sectionSchema";
-const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
-const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
-const LS_SCHEMA_KEY = "depot.notesSchema.v1";
-const AUTOSAVE_STORAGE_KEY = "surveyBrainAutosave";
-const LEGACY_SCHEMA_STORAGE_KEY = "depot-output-schema";
-const CHECKLIST_STATE_STORAGE_KEY = "depot-checklist-state";
-const WORKER_ENDPOINT_STORAGE_KEYS = ["depot.workerUrl", "depot-worker-url"];
+const STORAGE_KEYS_TO_CLEAR = [
+  "depot.notesSchema.v1",
+  "depot.sectionSchema",
+  "surveybrain-schema",
+  "depot.checklistConfig"
+];
 
 const state = {
   sections: [],
-  sectionsOrder: [],
-  checklistItems: []
+  items: []
 };
 
 let defaultSchema = { sections: [], checklist: { sectionsOrder: [], items: [] } };
-let pendingSectionFocusId = null;
-let pendingChecklistFocusId = null;
-let sectionIdCounter = 0;
-let checklistIdCounter = 0;
+let isDirty = false;
+let sectionCounter = 0;
+let itemCounter = 0;
 
-const sectionEditor = document.getElementById("settings-section-editor");
-const checklistEditor = document.getElementById("checklist-editor");
-const schemaTextarea = document.getElementById("settings-schema-json");
-const checklistTextarea = document.getElementById("settings-checklist-json");
-const statusEl = document.getElementById("settings-status");
-
-const btnSaveSchema = document.getElementById("btn-save-schema");
-const btnResetSchema = document.getElementById("btn-reset-schema");
-const btnSaveChecklist = document.getElementById("btn-save-checklist");
-const btnResetChecklist = document.getElementById("btn-reset-checklist");
-const btnForceReload = document.getElementById("btn-force-reload");
+const statusEl = document.querySelector("[data-status]");
+const sectionsListEl = document.querySelector("[data-sections-list]");
+const addSectionBtn = document.querySelector("[data-add-section]");
+const checklistListEl = document.querySelector("[data-checklist-list]");
+const addItemBtn = document.querySelector("[data-add-item]");
+const saveBtn = document.querySelector("[data-save]");
+const reloadBtn = document.querySelector("[data-reload]");
+const resetBtn = document.querySelector("[data-reset]");
+const clearBtn = document.querySelector("[data-clear]");
 
 function nextSectionId() {
-  sectionIdCounter += 1;
-  return `section-${Date.now()}-${sectionIdCounter}`;
+  sectionCounter += 1;
+  return `section-${Date.now()}-${sectionCounter}`;
 }
 
-function nextChecklistId() {
-  checklistIdCounter += 1;
-  return `checklist-${Date.now()}-${checklistIdCounter}`;
-}
-
-function createSection(name, { locked = false } = {}) {
-  return {
-    id: nextSectionId(),
-    name: typeof name === "string" ? name : "",
-    locked
-  };
-}
-
-function ensureFutureSection() {
-  let future = state.sections.find((section) => section.name === FUTURE_PLANS_NAME);
-  state.sections = state.sections.filter((section) => section.name !== FUTURE_PLANS_NAME);
-  if (!future) {
-    future = createSection(FUTURE_PLANS_NAME, { locked: true });
-  } else {
-    future.locked = true;
-    future.name = FUTURE_PLANS_NAME;
-  }
-  state.sections.push(future);
-}
-
-function syncSectionsOrder() {
-  const trimmedSections = state.sections
-    .map((section) => section.name.trim())
-    .filter((name) => name && name.toLowerCase() !== "arse_cover_notes");
-
-  const seen = new Set();
-  const order = [];
-  state.sectionsOrder.forEach((entry) => {
-    const trimmed = typeof entry === "string" ? entry.trim() : String(entry || "").trim();
-    if (!trimmed || seen.has(trimmed) || !trimmedSections.includes(trimmed)) return;
-    seen.add(trimmed);
-    order.push(trimmed);
-  });
-  trimmedSections.forEach((name) => {
-    if (!seen.has(name)) {
-      seen.add(name);
-      order.push(name);
-    }
-  });
-  if (!seen.has(FUTURE_PLANS_NAME)) {
-    order.push(FUTURE_PLANS_NAME);
-  } else {
-    const filtered = order.filter((name) => name !== FUTURE_PLANS_NAME);
-    filtered.push(FUTURE_PLANS_NAME);
-    order.length = 0;
-    filtered.forEach((name) => order.push(name));
-  }
-  state.sectionsOrder = order;
-}
-
-function copyChecklistItem(item) {
-  const base = item ? { ...item } : {};
-  const copy = {
-    ...base,
-    internalId: base.internalId || nextChecklistId()
-  };
-  if (typeof copy._materialsText !== "string") {
-    const materials = Array.isArray(copy.materials) ? copy.materials : [];
-    copy._materialsText = JSON.stringify(materials, null, 2);
-  }
-  copy.group = copy.group != null ? String(copy.group) : "";
-  copy.hint = copy.hint != null ? String(copy.hint) : "";
-  copy.plainText = copy.plainText != null ? String(copy.plainText) : "";
-  copy.naturalLanguage = copy.naturalLanguage != null ? String(copy.naturalLanguage) : "";
-  copy.section = copy.section != null ? String(copy.section) : (copy.depotSection != null ? String(copy.depotSection) : "");
-  if (copy.section) {
-    copy.depotSection = copy.section;
-  }
-  return copy;
-}
-
-function applySchema(schema) {
-  const source = schema || { sections: [], checklist: { sectionsOrder: [], items: [] } };
-  state.sections = (source.sections || []).map((name) => {
-    const isFuture = name === FUTURE_PLANS_NAME;
-    return {
-      id: nextSectionId(),
-      name,
-      locked: isFuture
-    };
-  });
-  if (!state.sections.length) {
-    state.sections.push(createSection(FUTURE_PLANS_NAME, { locked: true }));
-  }
-  state.sectionsOrder = Array.isArray(source.checklist?.sectionsOrder)
-    ? source.checklist.sectionsOrder.slice()
-    : [];
-  state.checklistItems = Array.isArray(source.checklist?.items)
-    ? source.checklist.items.map((item) => copyChecklistItem(item))
-    : [];
+function nextItemId() {
+  itemCounter += 1;
+  return `item-${Date.now()}-${itemCounter}`;
 }
 
 function setStatus(message, tone = "info") {
@@ -150,161 +51,142 @@ function setStatus(message, tone = "info") {
   }
 }
 
-function buildSchemaFromState({ strict = true } = {}) {
-  const workingSections = state.sections.map((section) => ({ ...section }));
-  const workingOrder = Array.isArray(state.sectionsOrder)
-    ? state.sectionsOrder.slice()
+function markDirty(message = "You have unsaved changes.") {
+  if (!isDirty) {
+    isDirty = true;
+  }
+  setStatus(message, "muted");
+}
+
+function clearDirty() {
+  isDirty = false;
+}
+
+function ensureFutureSection() {
+  const existingIndex = state.sections.findIndex((section) => section.name === FUTURE_PLANS_NAME);
+  if (existingIndex === -1) {
+    state.sections.push({ id: nextSectionId(), name: FUTURE_PLANS_NAME, locked: true });
+    return;
+  }
+  const [future] = state.sections.splice(existingIndex, 1);
+  state.sections.push({ ...future, name: FUTURE_PLANS_NAME, locked: true });
+}
+
+function applySchema(schema) {
+  const source = schema || { sections: [], checklist: { sectionsOrder: [], items: [] } };
+  sectionCounter = 0;
+  itemCounter = 0;
+
+  state.sections = (source.sections || []).map((name) => ({
+    id: nextSectionId(),
+    name: typeof name === "string" ? name : "",
+    locked: name === FUTURE_PLANS_NAME
+  }));
+  ensureFutureSection();
+
+  state.items = Array.isArray(source.checklist?.items)
+    ? source.checklist.items.map((item) => {
+      const copy = { ...item };
+      const sectionValue = item.section != null
+        ? String(item.section).trim()
+        : item.depotSection != null
+          ? String(item.depotSection).trim()
+          : "";
+      copy.uid = nextItemId();
+      copy.id = item.id != null ? String(item.id).trim() : "";
+      copy.label = item.label != null ? String(item.label).trim() : "";
+      copy.group = item.group != null ? String(item.group).trim() : "";
+      copy.hint = item.hint != null ? String(item.hint).trim() : "";
+      copy.section = sectionValue;
+      if (sectionValue) {
+        copy.depotSection = sectionValue;
+      } else {
+        delete copy.depotSection;
+      }
+      return copy;
+    })
     : [];
 
-  const sectionNames = [];
-  const seenSections = new Set();
-  let hasFuture = false;
-  workingSections.forEach((section) => {
-    const trimmed = typeof section.name === "string" ? section.name.trim() : "";
-    if (!trimmed || trimmed.toLowerCase() === "arse_cover_notes") return;
-    if (trimmed === FUTURE_PLANS_NAME) {
-      hasFuture = true;
-      return;
-    }
-    if (seenSections.has(trimmed)) return;
-    seenSections.add(trimmed);
-    sectionNames.push(trimmed);
-  });
-  if (hasFuture || !sectionNames.includes(FUTURE_PLANS_NAME)) {
-    sectionNames.push(FUTURE_PLANS_NAME);
-  }
-
-  const order = [];
-  const seenOrder = new Set();
-  workingOrder.forEach((entry) => {
-    const trimmed = typeof entry === "string" ? entry.trim() : String(entry || "").trim();
-    if (!trimmed || seenOrder.has(trimmed) || !sectionNames.includes(trimmed)) return;
-    seenOrder.add(trimmed);
-    order.push(trimmed);
-  });
-  sectionNames.forEach((name) => {
-    if (!seenOrder.has(name)) {
-      seenOrder.add(name);
-      order.push(name);
-    }
-  });
-
-  const items = [];
-  state.checklistItems.forEach((item) => {
-    const copy = { ...item };
-    const id = copy.id != null ? String(copy.id).trim() : "";
-    const label = copy.label != null ? String(copy.label).trim() : "";
-    if (!id || !label) {
-      if (strict) {
-        throw new Error("Checklist items must include both an id and label");
-      }
-      return;
-    }
-    copy.id = id;
-    copy.label = label;
-    copy.group = copy.group != null ? String(copy.group).trim() : "";
-    copy.hint = copy.hint != null ? String(copy.hint).trim() : "";
-    copy.section = copy.section != null ? String(copy.section).trim() : "";
-    if (copy.section) {
-      copy.depotSection = copy.section;
-    } else {
-      delete copy.depotSection;
-    }
-    copy.plainText = copy.plainText != null ? String(copy.plainText).trim() : "";
-    copy.naturalLanguage = copy.naturalLanguage != null ? String(copy.naturalLanguage).trim() : "";
-
-    if (typeof copy._materialsText === "string") {
-      const text = copy._materialsText.trim();
-      if (!text) {
-        copy.materials = [];
-      } else {
-        try {
-          const parsed = JSON.parse(text);
-          copy.materials = Array.isArray(parsed) ? parsed : [];
-        } catch (err) {
-          if (strict) {
-            throw new Error(`Item "${id}" has invalid materials JSON: ${err.message}`);
-          }
-          copy.materials = Array.isArray(copy.materials) ? copy.materials : [];
-        }
-      }
-    }
-
-    delete copy.internalId;
-    delete copy._materialsText;
-    items.push(copy);
-  });
-
-  return {
-    sections,
-    checklist: {
-      sectionsOrder: order,
-      items
-    }
-  };
+  clearDirty();
+  renderSections();
+  renderChecklist();
 }
 
-function updateJSONPreview() {
-  if (!schemaTextarea || !checklistTextarea) return;
-  try {
-    const schema = buildSchemaFromState({ strict: false });
-    const legacySections = schema.sections.map((name, idx) => ({
-      name,
-      description: name === FUTURE_PLANS_NAME ? FUTURE_PLANS_DESCRIPTION : "",
-      order: idx + 1
-    }));
-    schemaTextarea.value = JSON.stringify(legacySections, null, 2);
-    checklistTextarea.value = JSON.stringify(schema.checklist.items, null, 2);
-  } catch (err) {
-    schemaTextarea.value = "";
-    checklistTextarea.value = "";
-  }
+function moveSection(fromIdx, toIdx) {
+  if (toIdx < 0 || toIdx >= state.sections.length) return;
+  const target = state.sections[fromIdx];
+  if (!target || target.locked) return;
+  const destination = state.sections[toIdx];
+  if (destination && destination.locked && toIdx !== state.sections.length - 1) return;
+  state.sections.splice(fromIdx, 1);
+  state.sections.splice(toIdx, 0, target);
+  ensureFutureSection();
+  renderSections();
+  renderChecklist();
+  markDirty();
 }
 
-function renderSectionEditor() {
-  if (!sectionEditor) return;
-  sectionEditor.innerHTML = "";
-
-  if (!state.sections.length) {
-    ensureFutureSection();
+function removeSection(idx) {
+  const section = state.sections[idx];
+  if (!section || section.locked) return;
+  const removedName = section.name;
+  state.sections.splice(idx, 1);
+  ensureFutureSection();
+  if (removedName) {
+    state.items.forEach((item) => {
+      if (item.section === removedName || item.depotSection === removedName) {
+        delete item.section;
+        delete item.depotSection;
+      }
+    });
   }
+  renderSections();
+  renderChecklist();
+  markDirty();
+}
 
-  state.sections.forEach((section, idx) => {
+function renderSections() {
+  if (!sectionsListEl) return;
+  sectionsListEl.innerHTML = "";
+
+  state.sections.forEach((section, index) => {
     const row = document.createElement("div");
     row.className = "section-row";
 
-    const fields = document.createElement("div");
-    fields.className = "section-fields";
-
-    const nameInput = document.createElement("input");
-    nameInput.type = "text";
-    nameInput.placeholder = "Section name";
-    nameInput.value = section.name;
-    nameInput.disabled = section.locked;
-    nameInput.dataset.sectionId = section.id;
-    nameInput.addEventListener("focus", () => {
-      nameInput.dataset.initialName = section.name;
+    const field = document.createElement("input");
+    field.type = "text";
+    field.className = "section-name";
+    field.placeholder = "Section name";
+    field.value = section.name;
+    field.disabled = section.locked;
+    field.addEventListener("focus", () => {
+      section._previousName = section.name;
     });
-    nameInput.addEventListener("input", (event) => {
+    field.addEventListener("input", (event) => {
       section.name = event.target.value;
-      updateJSONPreview();
+      if (!section.locked) {
+        markDirty();
+      }
     });
-    nameInput.addEventListener("blur", (event) => {
-      const previous = (nameInput.dataset.initialName || "").trim();
-      const trimmed = event.target.value.trim();
-      section.name = trimmed;
+    field.addEventListener("blur", () => {
+      const previous = typeof section._previousName === "string" ? section._previousName : "";
+      const trimmed = section.name.trim();
+      section.name = section.locked ? FUTURE_PLANS_NAME : trimmed;
+      delete section._previousName;
       if (previous && trimmed && previous !== trimmed) {
-        state.checklistItems.forEach((item) => {
+        state.items.forEach((item) => {
           if (item.section === previous) {
             item.section = trimmed;
+          }
+          if (item.depotSection === previous) {
             item.depotSection = trimmed;
           }
         });
-        state.sectionsOrder = state.sectionsOrder.map((entry) => (entry === previous ? trimmed : entry));
       }
-      refreshUI();
+      ensureFutureSection();
+      renderSections();
+      renderChecklist();
     });
-    fields.appendChild(nameInput);
 
     const controls = document.createElement("div");
     controls.className = "section-controls";
@@ -312,484 +194,351 @@ function renderSectionEditor() {
     const upBtn = document.createElement("button");
     upBtn.type = "button";
     upBtn.textContent = "↑";
-    upBtn.disabled = idx === 0 || section.locked;
-    upBtn.addEventListener("click", () => {
-      if (idx === 0) return;
-      const [item] = state.sections.splice(idx, 1);
-      state.sections.splice(idx - 1, 0, item);
-      refreshUI();
-    });
+    upBtn.disabled = section.locked || index === 0;
+    upBtn.addEventListener("click", () => moveSection(index, index - 1));
 
     const downBtn = document.createElement("button");
     downBtn.type = "button";
     downBtn.textContent = "↓";
-    downBtn.disabled = idx === state.sections.length - 1 || section.locked;
-    downBtn.addEventListener("click", () => {
-      if (idx >= state.sections.length - 1) return;
-      const [item] = state.sections.splice(idx, 1);
-      state.sections.splice(idx + 1, 0, item);
-      refreshUI();
-    });
+    const isLast = index === state.sections.length - 1;
+    downBtn.disabled = section.locked || isLast || state.sections[index + 1]?.locked;
+    downBtn.addEventListener("click", () => moveSection(index, index + 1));
 
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
-    deleteBtn.textContent = "Delete";
+    deleteBtn.textContent = "Remove";
     deleteBtn.disabled = section.locked;
-    deleteBtn.addEventListener("click", () => {
-      if (section.locked) return;
-      const trimmed = section.name.trim();
-      state.sections.splice(idx, 1);
-      state.sectionsOrder = state.sectionsOrder.filter((entry) => entry !== trimmed);
-      state.checklistItems.forEach((item) => {
-        if (item.section === trimmed) {
-          item.section = "";
-          item.depotSection = "";
-        }
-      });
-      refreshUI();
-    });
+    deleteBtn.addEventListener("click", () => removeSection(index));
 
     controls.appendChild(upBtn);
     controls.appendChild(downBtn);
     controls.appendChild(deleteBtn);
 
-    row.appendChild(fields);
+    row.appendChild(field);
     row.appendChild(controls);
-    sectionEditor.appendChild(row);
-
-    if (pendingSectionFocusId && pendingSectionFocusId === section.id) {
-      setTimeout(() => {
-        nameInput.focus();
-        nameInput.select();
-      }, 0);
-    }
+    sectionsListEl.appendChild(row);
   });
-
-  const addRow = document.createElement("div");
-  addRow.className = "section-add-row";
-  const addBtn = document.createElement("button");
-  addBtn.type = "button";
-  addBtn.textContent = "Add section";
-  addBtn.addEventListener("click", () => {
-    ensureFutureSection();
-    const insertIndex = Math.max(0, state.sections.length - 1);
-    const newSection = createSection("");
-    state.sections.splice(insertIndex, 0, newSection);
-    pendingSectionFocusId = newSection.id;
-    refreshUI();
-  });
-  addRow.appendChild(addBtn);
-  sectionEditor.appendChild(addRow);
-
-  pendingSectionFocusId = null;
 }
 
-function renderChecklistEditor() {
-  if (!checklistEditor) return;
-  checklistEditor.innerHTML = "";
+function moveItem(fromIdx, toIdx) {
+  if (toIdx < 0 || toIdx >= state.items.length) return;
+  const [item] = state.items.splice(fromIdx, 1);
+  state.items.splice(toIdx, 0, item);
+  renderChecklist();
+  markDirty();
+}
 
-  if (!state.checklistItems.length) {
+function removeItem(idx) {
+  state.items.splice(idx, 1);
+  renderChecklist();
+  markDirty();
+}
+
+function renderChecklist() {
+  if (!checklistListEl) return;
+  checklistListEl.innerHTML = "";
+
+  if (!state.items.length) {
     const empty = document.createElement("p");
-    empty.className = "hint";
+    empty.className = "list-empty";
     empty.textContent = "No checklist items configured.";
-    checklistEditor.appendChild(empty);
+    checklistListEl.appendChild(empty);
+    return;
   }
 
-  const sectionOptions = state.sections
-    .map((section) => section.name.trim())
-    .filter((name, index, arr) => name && arr.indexOf(name) === index);
-
-  state.checklistItems.forEach((item, idx) => {
+  state.items.forEach((item, index) => {
     const card = document.createElement("div");
     card.className = "checklist-card";
-
-    const rowOne = document.createElement("div");
-    rowOne.className = "checklist-card-row";
 
     const idLabel = document.createElement("label");
     idLabel.textContent = "ID";
     const idInput = document.createElement("input");
     idInput.type = "text";
-    idInput.value = item.id || "";
+    idInput.value = item.id != null ? item.id : "";
     idInput.addEventListener("input", (event) => {
       item.id = event.target.value;
-      updateJSONPreview();
+      markDirty();
     });
     idLabel.appendChild(idInput);
-    rowOne.appendChild(idLabel);
-
-    const groupLabel = document.createElement("label");
-    groupLabel.textContent = "Group";
-    const groupInput = document.createElement("input");
-    groupInput.type = "text";
-    groupInput.value = item.group || "";
-    groupInput.addEventListener("input", (event) => {
-      item.group = event.target.value;
-      updateJSONPreview();
-    });
-    groupLabel.appendChild(groupInput);
-    rowOne.appendChild(groupLabel);
-
-    card.appendChild(rowOne);
-
-    const rowTwo = document.createElement("div");
-    rowTwo.className = "checklist-card-row";
-
-    const sectionLabel = document.createElement("label");
-    sectionLabel.textContent = "Section";
-    const sectionSelect = document.createElement("select");
-    const blankOption = document.createElement("option");
-    blankOption.value = "";
-    blankOption.textContent = "Select section";
-    sectionSelect.appendChild(blankOption);
-
-    sectionOptions.forEach((name) => {
-      const option = document.createElement("option");
-      option.value = name;
-      option.textContent = name;
-      sectionSelect.appendChild(option);
-    });
-
-    if (item.section && !sectionOptions.includes(item.section)) {
-      const option = document.createElement("option");
-      option.value = item.section;
-      option.textContent = `${item.section} (custom)`;
-      sectionSelect.appendChild(option);
-    }
-
-    sectionSelect.value = item.section || "";
-    sectionSelect.addEventListener("change", (event) => {
-      item.section = event.target.value;
-      item.depotSection = event.target.value;
-      updateJSONPreview();
-    });
-    sectionLabel.appendChild(sectionSelect);
-    rowTwo.appendChild(sectionLabel);
 
     const labelLabel = document.createElement("label");
     labelLabel.textContent = "Label";
     const labelInput = document.createElement("input");
     labelInput.type = "text";
-    labelInput.value = item.label || "";
+    labelInput.value = item.label != null ? item.label : "";
     labelInput.addEventListener("input", (event) => {
       item.label = event.target.value;
-      updateJSONPreview();
+      markDirty();
     });
     labelLabel.appendChild(labelInput);
-    rowTwo.appendChild(labelLabel);
 
-    card.appendChild(rowTwo);
+    const sectionLabel = document.createElement("label");
+    sectionLabel.textContent = "Depot section";
+    const sectionSelect = document.createElement("select");
+    const emptyOption = document.createElement("option");
+    emptyOption.value = "";
+    emptyOption.textContent = "— None —";
+    sectionSelect.appendChild(emptyOption);
+    state.sections.forEach((section) => {
+      const trimmedName = typeof section.name === "string" ? section.name.trim() : "";
+      if (!trimmedName) return;
+      const option = document.createElement("option");
+      option.value = trimmedName;
+      option.textContent = trimmedName;
+      if (trimmedName === FUTURE_PLANS_NAME && section.locked) {
+        option.textContent = `${trimmedName} (default)`;
+      }
+      sectionSelect.appendChild(option);
+    });
+    const initialSection = item.section || item.depotSection || "";
+    sectionSelect.value = initialSection;
+    sectionSelect.addEventListener("change", (event) => {
+      const value = event.target.value;
+      item.section = value;
+      if (value) {
+        item.depotSection = value;
+      } else {
+        delete item.depotSection;
+      }
+      markDirty();
+    });
+    sectionLabel.appendChild(sectionSelect);
+
+    const groupLabel = document.createElement("label");
+    groupLabel.textContent = "Group";
+    const groupInput = document.createElement("input");
+    groupInput.type = "text";
+    groupInput.value = item.group != null ? item.group : "";
+    groupInput.addEventListener("input", (event) => {
+      item.group = event.target.value;
+      markDirty();
+    });
+    groupLabel.appendChild(groupInput);
 
     const hintLabel = document.createElement("label");
     hintLabel.textContent = "Hint";
     const hintInput = document.createElement("textarea");
-    hintInput.value = item.hint || "";
+    hintInput.value = item.hint != null ? item.hint : "";
+    hintInput.rows = 2;
     hintInput.addEventListener("input", (event) => {
       item.hint = event.target.value;
-      updateJSONPreview();
+      markDirty();
     });
     hintLabel.appendChild(hintInput);
-    card.appendChild(hintLabel);
 
-    const plainTextLabel = document.createElement("label");
-    plainTextLabel.textContent = "Plain text";
-    const plainTextInput = document.createElement("textarea");
-    plainTextInput.value = item.plainText || "";
-    plainTextInput.addEventListener("input", (event) => {
-      item.plainText = event.target.value;
-      updateJSONPreview();
-    });
-    plainTextLabel.appendChild(plainTextInput);
-    card.appendChild(plainTextLabel);
-
-    const naturalLabel = document.createElement("label");
-    naturalLabel.textContent = "Natural language";
-    const naturalInput = document.createElement("textarea");
-    naturalInput.value = item.naturalLanguage || "";
-    naturalInput.addEventListener("input", (event) => {
-      item.naturalLanguage = event.target.value;
-      updateJSONPreview();
-    });
-    naturalLabel.appendChild(naturalInput);
-    card.appendChild(naturalLabel);
-
-    const materialsLabel = document.createElement("label");
-    materialsLabel.textContent = "Materials (JSON)";
-    const materialsInput = document.createElement("textarea");
-    materialsInput.value = item._materialsText || "[]";
-    materialsInput.addEventListener("input", (event) => {
-      item._materialsText = event.target.value;
-      updateJSONPreview();
-    });
-    materialsLabel.appendChild(materialsInput);
-    card.appendChild(materialsLabel);
+    const fields = document.createElement("div");
+    fields.className = "checklist-fields";
+    fields.appendChild(idLabel);
+    fields.appendChild(labelLabel);
+    fields.appendChild(sectionLabel);
+    fields.appendChild(groupLabel);
+    fields.appendChild(hintLabel);
 
     const actions = document.createElement("div");
-    actions.className = "checklist-card-actions";
+    actions.className = "checklist-actions";
 
     const upBtn = document.createElement("button");
     upBtn.type = "button";
     upBtn.textContent = "↑";
-    upBtn.disabled = idx === 0;
-    upBtn.addEventListener("click", () => {
-      if (idx === 0) return;
-      const [itemToMove] = state.checklistItems.splice(idx, 1);
-      state.checklistItems.splice(idx - 1, 0, itemToMove);
-      refreshUI();
-    });
-    actions.appendChild(upBtn);
+    upBtn.disabled = index === 0;
+    upBtn.addEventListener("click", () => moveItem(index, index - 1));
 
     const downBtn = document.createElement("button");
     downBtn.type = "button";
     downBtn.textContent = "↓";
-    downBtn.disabled = idx === state.checklistItems.length - 1;
-    downBtn.addEventListener("click", () => {
-      if (idx >= state.checklistItems.length - 1) return;
-      const [itemToMove] = state.checklistItems.splice(idx, 1);
-      state.checklistItems.splice(idx + 1, 0, itemToMove);
-      refreshUI();
-    });
-    actions.appendChild(downBtn);
+    downBtn.disabled = index === state.items.length - 1;
+    downBtn.addEventListener("click", () => moveItem(index, index + 1));
 
     const deleteBtn = document.createElement("button");
     deleteBtn.type = "button";
-    deleteBtn.textContent = "Delete";
-    deleteBtn.className = "danger";
-    deleteBtn.addEventListener("click", () => {
-      state.checklistItems.splice(idx, 1);
-      refreshUI();
-    });
+    deleteBtn.textContent = "Remove";
+    deleteBtn.addEventListener("click", () => removeItem(index));
+
+    actions.appendChild(upBtn);
+    actions.appendChild(downBtn);
     actions.appendChild(deleteBtn);
 
+    card.appendChild(fields);
     card.appendChild(actions);
-    checklistEditor.appendChild(card);
+    checklistListEl.appendChild(card);
+  });
+}
 
-    if (pendingChecklistFocusId && pendingChecklistFocusId === item.internalId) {
-      setTimeout(() => {
-        idInput.focus();
-        idInput.select();
-      }, 0);
+function addSection() {
+  const section = { id: nextSectionId(), name: "", locked: false };
+  const futureIndex = state.sections.findIndex((entry) => entry.name === FUTURE_PLANS_NAME);
+  if (futureIndex === -1) {
+    state.sections.push(section);
+  } else {
+    state.sections.splice(futureIndex, 0, section);
+  }
+  renderSections();
+  markDirty();
+}
+
+function addChecklistItem() {
+  state.items.push({
+    uid: nextItemId(),
+    id: "",
+    label: "",
+    section: "",
+    group: "",
+    hint: ""
+  });
+  renderChecklist();
+  markDirty();
+}
+
+function buildSchemaFromState() {
+  const trimmedSections = [];
+  const seenSections = new Set();
+
+  state.sections.forEach((section) => {
+    const trimmed = typeof section.name === "string" ? section.name.trim() : "";
+    if (!trimmed || trimmed.toLowerCase() === "arse_cover_notes") return;
+    if (trimmed === FUTURE_PLANS_NAME) return;
+    if (seenSections.has(trimmed)) return;
+    seenSections.add(trimmed);
+    trimmedSections.push(trimmed);
+  });
+
+  trimmedSections.push(FUTURE_PLANS_NAME);
+
+  const items = [];
+  const seenIds = new Set();
+  state.items.forEach((item) => {
+    const copy = { ...item };
+    delete copy.uid;
+    const id = copy.id != null ? String(copy.id).trim() : "";
+    const label = copy.label != null ? String(copy.label).trim() : "";
+    if (!id || !label || seenIds.has(id)) return;
+    seenIds.add(id);
+    copy.id = id;
+    copy.label = label;
+    copy.group = copy.group != null ? String(copy.group).trim() : "";
+    copy.hint = copy.hint != null ? String(copy.hint).trim() : "";
+    const section = copy.section != null ? String(copy.section).trim() : "";
+    copy.section = section;
+    if (section) {
+      copy.depotSection = section;
+    } else {
+      delete copy.depotSection;
     }
+    items.push(copy);
   });
 
-  const addRow = document.createElement("div");
-  addRow.className = "checklist-add-row";
-  const addBtn = document.createElement("button");
-  addBtn.type = "button";
-  addBtn.textContent = "Add item";
-  addBtn.addEventListener("click", () => {
-    const fallbackSection = state.sections
-      .map((section) => section.name.trim())
-      .find((name) => name && name !== FUTURE_PLANS_NAME) || "";
-    const newItem = copyChecklistItem({
-      id: `item_${Date.now()}`,
-      label: "",
-      group: "",
-      hint: "",
-      section: fallbackSection,
-      depotSection: fallbackSection,
-      plainText: "",
-      naturalLanguage: "",
-      materials: []
-    });
-    state.checklistItems.push(newItem);
-    pendingChecklistFocusId = newItem.internalId;
-    refreshUI();
-  });
-  addRow.appendChild(addBtn);
-  checklistEditor.appendChild(addRow);
-
-  pendingChecklistFocusId = null;
+  return {
+    sections: trimmedSections,
+    checklist: {
+      sectionsOrder: trimmedSections.slice(),
+      items
+    }
+  };
 }
 
-function refreshUI() {
-  ensureFutureSection();
-  syncSectionsOrder();
-  renderSectionEditor();
-  renderChecklistEditor();
-  updateJSONPreview();
-}
-
-function handleSave() {
+async function handleSave() {
   try {
-    const prepared = buildSchemaFromState({ strict: true });
-    const saved = saveSchema(prepared);
+    const schema = buildSchemaFromState();
+    const saved = saveSchema(schema);
     applySchema(saved);
-    refreshUI();
-    setStatus("Saved to this browser.", "success");
+    clearDirty();
+    setStatus("Settings saved to this device.", "success");
   } catch (err) {
     console.error(err);
-    setStatus(err?.message || "Failed to save settings.", "error");
+    setStatus("Failed to save settings.", "error");
   }
 }
 
-function handleResetSections() {
-  if (!defaultSchema || !defaultSchema.sections) return;
-  state.sections = defaultSchema.sections.map((name) => createSection(name, { locked: name === FUTURE_PLANS_NAME }));
-  state.sectionsOrder = defaultSchema.checklist.sectionsOrder.slice();
-  const validNames = new Set(state.sections.map((section) => section.name.trim()).filter(Boolean));
-  state.checklistItems.forEach((item) => {
-    if (item.section && !validNames.has(item.section)) {
-      item.section = "";
-      item.depotSection = "";
+async function handleReload({ silent = false } = {}) {
+  try {
+    const schema = await loadSchema();
+    applySchema(schema);
+    if (!silent) {
+      setStatus("Reloaded saved settings.", "muted");
     }
-  });
-  refreshUI();
-  setStatus("Sections reset to defaults.", "muted");
-}
-
-function handleResetChecklist() {
-  if (!defaultSchema || !defaultSchema.checklist) return;
-  const clone = defaultSchema.checklist.items.map((item) => copyChecklistItem(item));
-  state.checklistItems = clone;
-  state.sectionsOrder = defaultSchema.checklist.sectionsOrder.slice();
-  refreshUI();
-  setStatus("Checklist reset to defaults.", "muted");
-}
-
-function clearLocalDepotStorage() {
-  const knownKeys = [
-    SECTION_STORAGE_KEY,
-    LEGACY_SECTION_STORAGE_KEY,
-    CHECKLIST_STORAGE_KEY,
-    LS_SCHEMA_KEY,
-    AUTOSAVE_STORAGE_KEY,
-    LEGACY_SCHEMA_STORAGE_KEY,
-    CHECKLIST_STATE_STORAGE_KEY,
-    ...WORKER_ENDPOINT_STORAGE_KEYS
-  ];
-  try {
-    knownKeys.forEach((key) => {
-      if (!key) return;
-      try {
-        localStorage.removeItem(key);
-      } catch (_) {
-        // ignore per-key failures
-      }
-    });
-  } catch (_) {
-    // ignore inability to access localStorage
-  }
-
-  const shouldClear = (key) => /^(depot[.-]|surveyBrain)/.test(key || "");
-
-  try {
-    const extraKeys = [];
-    for (let i = 0; i < localStorage.length; i += 1) {
-      const key = localStorage.key(i);
-      if (key && shouldClear(key) && !knownKeys.includes(key)) {
-        extraKeys.push(key);
-      }
-    }
-    extraKeys.forEach((key) => {
-      try {
-        localStorage.removeItem(key);
-      } catch (_) {
-        // ignore
-      }
-    });
-  } catch (_) {
-    // ignore inability to enumerate localStorage
-  }
-
-  try {
-    const sessionKeys = [];
-    for (let i = 0; i < sessionStorage.length; i += 1) {
-      const key = sessionStorage.key(i);
-      if (key && shouldClear(key)) {
-        sessionKeys.push(key);
-      }
-    }
-    sessionKeys.forEach((key) => {
-      try {
-        sessionStorage.removeItem(key);
-      } catch (_) {
-        // ignore
-      }
-    });
-  } catch (_) {
-    // ignore sessionStorage access issues
-  }
-}
-
-async function unregisterServiceWorkers() {
-  if (!("serviceWorker" in navigator)) return;
-  try {
-    const registrations = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(registrations.map((registration) => registration.unregister().catch(() => false)));
+    return true;
   } catch (err) {
-    console.warn("Failed to unregister service workers", err);
+    console.error(err);
+    setStatus("Failed to reload settings.", "error");
+    return false;
   }
 }
 
-async function clearAppCaches() {
-  if (typeof window === "undefined" || !("caches" in window)) return;
+async function handleReset() {
   try {
-    const keys = await caches.keys();
-    await Promise.all(keys.map((key) => caches.delete(key).catch(() => false)));
+    if (!defaultSchema || !Array.isArray(defaultSchema.sections)) {
+      defaultSchema = await getDefaultSchema();
+    }
+    applySchema(defaultSchema);
+    markDirty("Defaults loaded. Save to apply them.");
   } catch (err) {
-    console.warn("Failed to clear caches", err);
+    console.error(err);
+    setStatus("Failed to load defaults.", "error");
   }
 }
 
-async function handleForceReload(event) {
-  const confirmation = window.confirm(
-    "This will clear Depot overrides on this device and reload. Continue?"
-  );
-  if (!confirmation) return;
-
-  const button = event?.currentTarget || null;
-  if (button) {
-    button.disabled = true;
-    button.textContent = "Clearing…";
+async function clearOverrides() {
+  try {
+    STORAGE_KEYS_TO_CLEAR.forEach((key) => {
+      localStorage.removeItem(key);
+    });
+    const reloaded = await handleReload({ silent: true });
+    if (reloaded) {
+      setStatus("Local overrides cleared.", "success");
+    }
+  } catch (err) {
+    console.error(err);
+    setStatus("Failed to clear local overrides.", "error");
   }
-
-  clearLocalDepotStorage();
-  await unregisterServiceWorkers();
-  await clearAppCaches();
-
-  if (button) {
-    button.textContent = "Reloading…";
-  }
-
-  window.location.reload();
 }
 
 async function init() {
   setStatus("Loading settings…", "muted");
   try {
-    const [defaults, loaded] = await Promise.all([
-      getDefaultSchema(),
-      loadSchema()
-    ]);
-    defaultSchema = defaults;
-    applySchema(loaded);
-    refreshUI();
-    setStatus("Loaded. Changes are stored locally in this browser.");
+    defaultSchema = await getDefaultSchema();
+    const schema = await loadSchema();
+    applySchema(schema);
+    setStatus("Settings loaded.", "muted");
   } catch (err) {
     console.error(err);
-    setStatus("Failed to load schema information.", "error");
+    setStatus("Failed to load settings.", "error");
   }
 }
 
-if (btnSaveSchema) {
-  btnSaveSchema.addEventListener("click", handleSave);
-}
-if (btnSaveChecklist) {
-  btnSaveChecklist.addEventListener("click", handleSave);
-}
-if (btnResetSchema) {
-  btnResetSchema.addEventListener("click", handleResetSections);
-}
-if (btnResetChecklist) {
-  btnResetChecklist.addEventListener("click", handleResetChecklist);
-}
-if (btnForceReload) {
-  btnForceReload.addEventListener("click", handleForceReload);
+if (addSectionBtn) {
+  addSectionBtn.addEventListener("click", () => {
+    addSection();
+  });
 }
 
-if (document.readyState === "loading") {
-  window.addEventListener("DOMContentLoaded", init);
-} else {
-  init();
+if (addItemBtn) {
+  addItemBtn.addEventListener("click", () => {
+    addChecklistItem();
+  });
 }
+
+if (saveBtn) {
+  saveBtn.addEventListener("click", () => {
+    handleSave();
+  });
+}
+
+if (reloadBtn) {
+  reloadBtn.addEventListener("click", () => {
+    handleReload();
+  });
+}
+
+if (resetBtn) {
+  resetBtn.addEventListener("click", () => {
+    handleReset();
+  });
+}
+
+if (clearBtn) {
+  clearBtn.addEventListener("click", () => {
+    clearOverrides();
+  });
+}
+
+init();

--- a/settings.html
+++ b/settings.html
@@ -6,309 +6,328 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <style>
     :root {
-      --bg: #eef2f7;
+      color-scheme: light;
+      --bg: #f6f8fb;
       --card: #ffffff;
-      --border: #d4dbe5;
-      --accent: #0f766e;
+      --border: #d9e0eb;
+      --accent: #2563eb;
+      --accent-dark: #1d4ed8;
       --danger: #b91c1c;
-      --muted: #64748b;
-      --radius: 16px;
+      --text-muted: #64748b;
+      --radius: 14px;
     }
-    * { box-sizing: border-box; }
+
+    * {
+      box-sizing: border-box;
+    }
+
     body {
       margin: 0;
-      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       background: var(--bg);
-      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color: #0f172a;
+      min-height: 100vh;
       display: flex;
       justify-content: center;
-      align-items: flex-start;
-      padding: 40px 16px;
+      padding: 32px 16px;
     }
+
     main {
       width: min(960px, 100%);
       background: var(--card);
-      border: 1px solid var(--border);
       border-radius: var(--radius);
-      padding: 24px;
-      box-shadow: 0 10px 20px rgba(15, 23, 42, 0.05);
+      border: 1px solid var(--border);
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+      padding: 28px;
       display: flex;
       flex-direction: column;
-      gap: 24px;
+      gap: 32px;
     }
-    h1 {
-      margin: 0;
-      font-size: 1.4rem;
-    }
-    section h2 {
-      margin: 0 0 8px;
-      font-size: 1rem;
-    }
-    p {
-      margin: 0 0 12px;
-      color: var(--muted);
-      font-size: 0.85rem;
-    }
-    textarea {
-      width: 100%;
-      min-height: 240px;
-      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-      border-radius: 12px;
-      border: 1px solid #cbd5e1;
-      padding: 12px;
-      font-size: 0.8rem;
-      background: #f8fafc;
-      color: #0f172a;
-      resize: vertical;
-    }
-    input[type="url"],
-    input[type="password"] {
-      width: 100%;
-      border-radius: 12px;
-      border: 1px solid #cbd5e1;
-      padding: 10px 12px;
-      font-size: 0.8rem;
-      background: #f8fafc;
-      color: #0f172a;
-    }
-    textarea#settings-schema-json {
-      min-height: 180px;
-    }
-    .btn-row {
-      margin-top: 10px;
+
+    header {
       display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
+      flex-direction: column;
+      gap: 12px;
     }
-    button {
-      border: none;
-      background: var(--accent);
-      color: #fff;
-      border-radius: 999px;
-      padding: 8px 16px;
-      font-size: 0.78rem;
-      font-weight: 600;
-      cursor: pointer;
-      display: inline-flex;
-      gap: 6px;
-      align-items: center;
+
+    header h1 {
+      margin: 0;
+      font-size: 1.45rem;
+      letter-spacing: -0.01em;
     }
-    button.secondary {
-      background: transparent;
+
+    header p {
+      margin: 0;
+      color: var(--text-muted);
+      font-size: 0.9rem;
+    }
+
+    a.back-link {
       color: var(--accent);
-      border: 1px solid var(--accent);
-    }
-    button.danger {
-      background: var(--danger);
-      color: #fff;
-    }
-    .hint {
-      margin-top: 6px;
-      font-size: 0.8rem;
-      color: var(--muted);
-    }
-    .status {
-      margin-top: -8px;
+      text-decoration: none;
       font-size: 0.85rem;
-      color: var(--muted);
+    }
+
+    .status {
       min-height: 1.2em;
+      font-size: 0.85rem;
+      color: var(--text-muted);
     }
+
     .status--success {
-      color: var(--accent);
+      color: #047857;
     }
+
     .status--error {
       color: var(--danger);
     }
-    .status--muted {
-      color: var(--muted);
+
+    section {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
     }
-    textarea[readonly] {
-      background: #f1f5f9;
+
+    section > header {
+      gap: 6px;
     }
-    a.back-link {
-      font-size: 0.8rem;
-      color: var(--accent);
-      text-decoration: none;
-      margin-bottom: -12px;
+
+    section > header h2 {
+      margin: 0;
+      font-size: 1.05rem;
     }
-    .section-editor {
-      margin-top: 12px;
-      margin-bottom: 12px;
+
+    section > header p {
+      margin: 0;
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      line-height: 1.4;
+    }
+
+    .stack {
       display: flex;
       flex-direction: column;
       gap: 12px;
     }
+
     .section-row {
       display: flex;
       gap: 12px;
-      align-items: flex-start;
-      border: 1px solid #e2e8f0;
-      border-radius: 12px;
-      padding: 12px;
+      align-items: center;
       background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 12px;
     }
-    .section-fields {
+
+    .section-row input[type="text"] {
       flex: 1;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    .section-fields input,
-    .section-fields textarea {
-      width: 100%;
       border-radius: 8px;
       border: 1px solid #cbd5e1;
       padding: 8px 10px;
-      font-size: 0.8rem;
+      font-size: 0.9rem;
       background: #fff;
-      color: #0f172a;
     }
-    .section-fields textarea {
-      min-height: 60px;
-      resize: vertical;
+
+    .section-row input[disabled] {
+      background: #e2e8f0;
+      color: #475569;
     }
+
     .section-controls {
       display: flex;
-      flex-direction: column;
       gap: 6px;
     }
+
     .section-controls button {
+      border: none;
       background: #e2e8f0;
       color: #0f172a;
-      border-radius: 8px;
       padding: 6px 10px;
-      font-size: 0.7rem;
-      border: none;
+      border-radius: 8px;
+      font-size: 0.8rem;
+      cursor: pointer;
     }
+
     .section-controls button:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
-    .section-add-row {
+
+    .section-actions {
       display: flex;
       justify-content: flex-start;
     }
-    .section-add-row button {
+
+    .section-actions button {
       background: var(--accent);
-      color: #fff;
       border: none;
+      color: #fff;
+      padding: 8px 14px;
       border-radius: 999px;
-      padding: 6px 14px;
-      font-size: 0.75rem;
+      font-size: 0.82rem;
       cursor: pointer;
     }
-    .checklist-editor {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-      margin-bottom: 12px;
-    }
+
     .checklist-card {
-      background: #fff;
-      border: 1px solid var(--border);
+      border: 1px solid #e2e8f0;
       border-radius: 12px;
-      padding: 12px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-    .checklist-card-row {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-      gap: 8px;
-    }
-    .checklist-card label {
-      font-size: 0.7rem;
-      font-weight: 600;
-      color: var(--muted);
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    .checklist-card input,
-    .checklist-card select,
-    .checklist-card textarea {
-      font-size: 0.75rem;
-      padding: 6px 8px;
-      border-radius: 8px;
-      border: 1px solid var(--border);
+      padding: 16px;
       background: #f8fafc;
+      display: grid;
+      gap: 12px;
+    }
+
+    .checklist-fields {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    }
+
+    .checklist-fields label {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+    }
+
+    .checklist-fields input,
+    .checklist-fields select,
+    .checklist-fields textarea {
+      font-size: 0.85rem;
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid #cbd5e1;
+      background: #fff;
       color: #0f172a;
     }
-    .checklist-card textarea {
-      min-height: 48px;
+
+    .checklist-fields textarea {
       resize: vertical;
+      min-height: 56px;
     }
-    .checklist-card-actions {
+
+    .checklist-actions {
       display: flex;
+      gap: 8px;
       justify-content: flex-end;
-      gap: 6px;
     }
-    .checklist-card-actions button {
+
+    .checklist-actions button {
+      border: none;
       background: #e2e8f0;
       color: #0f172a;
-      border: none;
-      border-radius: 8px;
       padding: 6px 10px;
-      font-size: 0.7rem;
+      border-radius: 8px;
+      font-size: 0.8rem;
       cursor: pointer;
     }
-    .checklist-card-actions button:disabled {
+
+    .checklist-actions button:disabled {
       opacity: 0.5;
       cursor: not-allowed;
     }
-    .checklist-card-actions button.danger {
+
+    .checklist-actions button:last-child {
       background: var(--danger);
       color: #fff;
     }
-    .checklist-add-row {
-      display: flex;
-      justify-content: flex-start;
+
+    .list-empty {
+      font-size: 0.85rem;
+      color: var(--text-muted);
+      font-style: italic;
     }
-    .checklist-add-row button {
-      background: var(--accent);
-      color: #fff;
+
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+
+    .actions button {
       border: none;
       border-radius: 999px;
-      padding: 6px 14px;
-      font-size: 0.75rem;
+      padding: 10px 18px;
+      font-size: 0.9rem;
+      font-weight: 600;
       cursor: pointer;
+      background: var(--accent);
+      color: #fff;
+      transition: background 0.2s ease;
+    }
+
+    .actions button:hover {
+      background: var(--accent-dark);
+    }
+
+    .actions button.secondary {
+      background: transparent;
+      border: 1px solid var(--accent);
+      color: var(--accent);
+    }
+
+    .actions button.danger {
+      background: var(--danger);
+      color: #fff;
+    }
+
+    @media (max-width: 720px) {
+      body {
+        padding: 16px;
+      }
+
+      main {
+        padding: 20px;
+      }
+
+      .checklist-fields {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
 </head>
 <body>
   <main>
-    <a class="back-link" href="index.html">← Back to notes</a>
-    <h1>Depot Settings</h1>
-    <div id="settings-status" class="status" aria-live="polite"></div>
+    <header>
+      <a href="index.html" class="back-link">← Back to notes</a>
+      <h1>Depot settings</h1>
+      <p>Configure Depot section names and checklist items. Changes are stored in this browser only.</p>
+    </header>
+
+    <div class="status" data-status aria-live="polite"></div>
+
     <section>
-      <h2>Checklist configuration</h2>
-      <p>Edit the mapping from checklist ticks to Depot notes &amp; materials. Changes are stored locally on this device.</p>
-      <div id="checklist-editor" class="checklist-editor"></div>
-      <textarea id="settings-checklist-json" readonly></textarea>
-      <div class="btn-row">
-        <button id="btn-save-checklist">Save (this device)</button>
-        <button id="btn-reset-checklist" class="secondary">Reset to defaults</button>
+      <header>
+        <h2>Depot sections</h2>
+        <p>Edit the section names and order. “Future plans” is kept automatically at the end.</p>
+      </header>
+      <div data-sections-list class="stack"></div>
+      <div class="section-actions">
+        <button type="button" data-add-section>Add section</button>
       </div>
     </section>
+
     <section>
-      <h2>Depot output schema</h2>
-      <p>Control Depot section names and ordering. Overrides apply locally until cleared.</p>
-      <div id="settings-section-editor" class="section-editor"></div>
-      <textarea id="settings-schema-json" readonly></textarea>
-      <div class="btn-row">
-        <button id="btn-save-schema">Save (this device)</button>
-        <button id="btn-reset-schema" class="secondary">Reset to defaults</button>
+      <header>
+        <h2>Checklist items</h2>
+        <p>Set the ID, label, and optional metadata for checklist items. Items with empty ID or label are ignored when saved.</p>
+      </header>
+      <div data-checklist-list class="stack"></div>
+      <div class="section-actions">
+        <button type="button" data-add-item>Add checklist item</button>
       </div>
     </section>
-    <section>
-      <h2>Advanced</h2>
-      <p>Clear all locally stored Depot data and reload the app from the network.</p>
-      <div class="btn-row">
-        <button id="btn-force-reload" class="danger">Force reload (clear local data)</button>
-      </div>
-    </section>
+
+    <div class="actions">
+      <button type="button" data-save>Save changes</button>
+      <button type="button" class="secondary" data-reload>Reload saved</button>
+      <button type="button" class="secondary" data-reset>Reset to defaults</button>
+      <button type="button" class="danger" data-clear>Clear local overrides</button>
+    </div>
   </main>
   <script type="module" src="./js/settingsPage.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- rebuild the settings page with a streamlined layout for editing Depot sections and checklist items
- replace the legacy settings script with a schema-aware editor that reorders, saves, and clears overrides via the new schema engine

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a2460a30832ca8a4670470175844)