### PR TITLE
refactor: implement schema engine + rebuild settings page

### DIFF
--- a/js/settingsPage.js
+++ b/js/settingsPage.js
@@ -1,544 +1,124 @@
+// js/settingsPage.js
 import { loadSchema, saveSchema, getDefaultSchema } from "./schema.js";
 
-const FUTURE_PLANS_NAME = "Future plans";
-const STORAGE_KEYS_TO_CLEAR = [
-  "depot.notesSchema.v1",
-  "depot.sectionSchema",
-  "surveybrain-schema",
-  "depot.checklistConfig"
-];
-
-const state = {
-  sections: [],
-  items: []
-};
-
-let defaultSchema = { sections: [], checklist: { sectionsOrder: [], items: [] } };
-let isDirty = false;
-let sectionCounter = 0;
-let itemCounter = 0;
-
-const statusEl = document.querySelector("[data-status]");
-const sectionsListEl = document.querySelector("[data-sections-list]");
-const addSectionBtn = document.querySelector("[data-add-section]");
-const checklistListEl = document.querySelector("[data-checklist-list]");
-const addItemBtn = document.querySelector("[data-add-item]");
-const saveBtn = document.querySelector("[data-save]");
-const reloadBtn = document.querySelector("[data-reload]");
-const resetBtn = document.querySelector("[data-reset]");
-const clearBtn = document.querySelector("[data-clear]");
-
-function nextSectionId() {
-  sectionCounter += 1;
-  return `section-${Date.now()}-${sectionCounter}`;
+function $(id) {
+  return document.getElementById(id);
 }
 
-function nextItemId() {
-  itemCounter += 1;
-  return `item-${Date.now()}-${itemCounter}`;
-}
+async function initialise() {
+  const sectionsInput = $("sectionsJson");
+  const checklistInput = $("checklistJson");
+  const summaryEl = $("schemaSummary");
+  const saveSectionsBtn = $("saveSectionsBtn");
+  const resetSectionsBtn = $("resetSectionsBtn");
+  const saveChecklistBtn = $("saveChecklistBtn");
+  const resetChecklistBtn = $("resetChecklistBtn");
+  const resetAllBtn = $("resetAllBtn");
+  const backBtn = $("backBtn");
 
-function setStatus(message, tone = "info") {
-  if (!statusEl) return;
-  statusEl.textContent = message || "";
-  statusEl.className = "status";
-  if (tone === "success") {
-    statusEl.classList.add("status--success");
-  } else if (tone === "error") {
-    statusEl.classList.add("status--error");
-  } else if (tone === "muted") {
-    statusEl.classList.add("status--muted");
-  }
-}
+  let current = await loadSchema();
 
-function markDirty(message = "You have unsaved changes.") {
-  if (!isDirty) {
-    isDirty = true;
-  }
-  setStatus(message, "muted");
-}
-
-function clearDirty() {
-  isDirty = false;
-}
-
-function ensureFutureSection() {
-  const existingIndex = state.sections.findIndex((section) => section.name === FUTURE_PLANS_NAME);
-  if (existingIndex === -1) {
-    state.sections.push({ id: nextSectionId(), name: FUTURE_PLANS_NAME, locked: true });
-    return;
-  }
-  const [future] = state.sections.splice(existingIndex, 1);
-  state.sections.push({ ...future, name: FUTURE_PLANS_NAME, locked: true });
-}
-
-function applySchema(schema) {
-  const source = schema || { sections: [], checklist: { sectionsOrder: [], items: [] } };
-  sectionCounter = 0;
-  itemCounter = 0;
-
-  state.sections = (source.sections || []).map((name) => ({
-    id: nextSectionId(),
-    name: typeof name === "string" ? name : "",
-    locked: name === FUTURE_PLANS_NAME
-  }));
-  ensureFutureSection();
-
-  state.items = Array.isArray(source.checklist?.items)
-    ? source.checklist.items.map((item) => {
-      const copy = { ...item };
-      const sectionValue = item.section != null
-        ? String(item.section).trim()
-        : item.depotSection != null
-          ? String(item.depotSection).trim()
-          : "";
-      copy.uid = nextItemId();
-      copy.id = item.id != null ? String(item.id).trim() : "";
-      copy.label = item.label != null ? String(item.label).trim() : "";
-      copy.group = item.group != null ? String(item.group).trim() : "";
-      copy.hint = item.hint != null ? String(item.hint).trim() : "";
-      copy.section = sectionValue;
-      if (sectionValue) {
-        copy.depotSection = sectionValue;
-      } else {
-        delete copy.depotSection;
-      }
-      return copy;
-    })
-    : [];
-
-  clearDirty();
-  renderSections();
-  renderChecklist();
-}
-
-function moveSection(fromIdx, toIdx) {
-  if (toIdx < 0 || toIdx >= state.sections.length) return;
-  const target = state.sections[fromIdx];
-  if (!target || target.locked) return;
-  const destination = state.sections[toIdx];
-  if (destination && destination.locked && toIdx !== state.sections.length - 1) return;
-  state.sections.splice(fromIdx, 1);
-  state.sections.splice(toIdx, 0, target);
-  ensureFutureSection();
-  renderSections();
-  renderChecklist();
-  markDirty();
-}
-
-function removeSection(idx) {
-  const section = state.sections[idx];
-  if (!section || section.locked) return;
-  const removedName = section.name;
-  state.sections.splice(idx, 1);
-  ensureFutureSection();
-  if (removedName) {
-    state.items.forEach((item) => {
-      if (item.section === removedName || item.depotSection === removedName) {
-        delete item.section;
-        delete item.depotSection;
-      }
-    });
-  }
-  renderSections();
-  renderChecklist();
-  markDirty();
-}
-
-function renderSections() {
-  if (!sectionsListEl) return;
-  sectionsListEl.innerHTML = "";
-
-  state.sections.forEach((section, index) => {
-    const row = document.createElement("div");
-    row.className = "section-row";
-
-    const field = document.createElement("input");
-    field.type = "text";
-    field.className = "section-name";
-    field.placeholder = "Section name";
-    field.value = section.name;
-    field.disabled = section.locked;
-    field.addEventListener("focus", () => {
-      section._previousName = section.name;
-    });
-    field.addEventListener("input", (event) => {
-      section.name = event.target.value;
-      if (!section.locked) {
-        markDirty();
-      }
-    });
-    field.addEventListener("blur", () => {
-      const previous = typeof section._previousName === "string" ? section._previousName : "";
-      const trimmed = section.name.trim();
-      section.name = section.locked ? FUTURE_PLANS_NAME : trimmed;
-      delete section._previousName;
-      if (previous && trimmed && previous !== trimmed) {
-        state.items.forEach((item) => {
-          if (item.section === previous) {
-            item.section = trimmed;
-          }
-          if (item.depotSection === previous) {
-            item.depotSection = trimmed;
-          }
-        });
-      }
-      ensureFutureSection();
-      renderSections();
-      renderChecklist();
-    });
-
-    const controls = document.createElement("div");
-    controls.className = "section-controls";
-
-    const upBtn = document.createElement("button");
-    upBtn.type = "button";
-    upBtn.textContent = "↑";
-    upBtn.disabled = section.locked || index === 0;
-    upBtn.addEventListener("click", () => moveSection(index, index - 1));
-
-    const downBtn = document.createElement("button");
-    downBtn.type = "button";
-    downBtn.textContent = "↓";
-    const isLast = index === state.sections.length - 1;
-    downBtn.disabled = section.locked || isLast || state.sections[index + 1]?.locked;
-    downBtn.addEventListener("click", () => moveSection(index, index + 1));
-
-    const deleteBtn = document.createElement("button");
-    deleteBtn.type = "button";
-    deleteBtn.textContent = "Remove";
-    deleteBtn.disabled = section.locked;
-    deleteBtn.addEventListener("click", () => removeSection(index));
-
-    controls.appendChild(upBtn);
-    controls.appendChild(downBtn);
-    controls.appendChild(deleteBtn);
-
-    row.appendChild(field);
-    row.appendChild(controls);
-    sectionsListEl.appendChild(row);
-  });
-}
-
-function moveItem(fromIdx, toIdx) {
-  if (toIdx < 0 || toIdx >= state.items.length) return;
-  const [item] = state.items.splice(fromIdx, 1);
-  state.items.splice(toIdx, 0, item);
-  renderChecklist();
-  markDirty();
-}
-
-function removeItem(idx) {
-  state.items.splice(idx, 1);
-  renderChecklist();
-  markDirty();
-}
-
-function renderChecklist() {
-  if (!checklistListEl) return;
-  checklistListEl.innerHTML = "";
-
-  if (!state.items.length) {
-    const empty = document.createElement("p");
-    empty.className = "list-empty";
-    empty.textContent = "No checklist items configured.";
-    checklistListEl.appendChild(empty);
-    return;
-  }
-
-  state.items.forEach((item, index) => {
-    const card = document.createElement("div");
-    card.className = "checklist-card";
-
-    const idLabel = document.createElement("label");
-    idLabel.textContent = "ID";
-    const idInput = document.createElement("input");
-    idInput.type = "text";
-    idInput.value = item.id != null ? item.id : "";
-    idInput.addEventListener("input", (event) => {
-      item.id = event.target.value;
-      markDirty();
-    });
-    idLabel.appendChild(idInput);
-
-    const labelLabel = document.createElement("label");
-    labelLabel.textContent = "Label";
-    const labelInput = document.createElement("input");
-    labelInput.type = "text";
-    labelInput.value = item.label != null ? item.label : "";
-    labelInput.addEventListener("input", (event) => {
-      item.label = event.target.value;
-      markDirty();
-    });
-    labelLabel.appendChild(labelInput);
-
-    const sectionLabel = document.createElement("label");
-    sectionLabel.textContent = "Depot section";
-    const sectionSelect = document.createElement("select");
-    const emptyOption = document.createElement("option");
-    emptyOption.value = "";
-    emptyOption.textContent = "— None —";
-    sectionSelect.appendChild(emptyOption);
-    state.sections.forEach((section) => {
-      const trimmedName = typeof section.name === "string" ? section.name.trim() : "";
-      if (!trimmedName) return;
-      const option = document.createElement("option");
-      option.value = trimmedName;
-      option.textContent = trimmedName;
-      if (trimmedName === FUTURE_PLANS_NAME && section.locked) {
-        option.textContent = `${trimmedName} (default)`;
-      }
-      sectionSelect.appendChild(option);
-    });
-    const initialSection = item.section || item.depotSection || "";
-    sectionSelect.value = initialSection;
-    sectionSelect.addEventListener("change", (event) => {
-      const value = event.target.value;
-      item.section = value;
-      if (value) {
-        item.depotSection = value;
-      } else {
-        delete item.depotSection;
-      }
-      markDirty();
-    });
-    sectionLabel.appendChild(sectionSelect);
-
-    const groupLabel = document.createElement("label");
-    groupLabel.textContent = "Group";
-    const groupInput = document.createElement("input");
-    groupInput.type = "text";
-    groupInput.value = item.group != null ? item.group : "";
-    groupInput.addEventListener("input", (event) => {
-      item.group = event.target.value;
-      markDirty();
-    });
-    groupLabel.appendChild(groupInput);
-
-    const hintLabel = document.createElement("label");
-    hintLabel.textContent = "Hint";
-    const hintInput = document.createElement("textarea");
-    hintInput.value = item.hint != null ? item.hint : "";
-    hintInput.rows = 2;
-    hintInput.addEventListener("input", (event) => {
-      item.hint = event.target.value;
-      markDirty();
-    });
-    hintLabel.appendChild(hintInput);
-
-    const fields = document.createElement("div");
-    fields.className = "checklist-fields";
-    fields.appendChild(idLabel);
-    fields.appendChild(labelLabel);
-    fields.appendChild(sectionLabel);
-    fields.appendChild(groupLabel);
-    fields.appendChild(hintLabel);
-
-    const actions = document.createElement("div");
-    actions.className = "checklist-actions";
-
-    const upBtn = document.createElement("button");
-    upBtn.type = "button";
-    upBtn.textContent = "↑";
-    upBtn.disabled = index === 0;
-    upBtn.addEventListener("click", () => moveItem(index, index - 1));
-
-    const downBtn = document.createElement("button");
-    downBtn.type = "button";
-    downBtn.textContent = "↓";
-    downBtn.disabled = index === state.items.length - 1;
-    downBtn.addEventListener("click", () => moveItem(index, index + 1));
-
-    const deleteBtn = document.createElement("button");
-    deleteBtn.type = "button";
-    deleteBtn.textContent = "Remove";
-    deleteBtn.addEventListener("click", () => removeItem(index));
-
-    actions.appendChild(upBtn);
-    actions.appendChild(downBtn);
-    actions.appendChild(deleteBtn);
-
-    card.appendChild(fields);
-    card.appendChild(actions);
-    checklistListEl.appendChild(card);
-  });
-}
-
-function addSection() {
-  const section = { id: nextSectionId(), name: "", locked: false };
-  const futureIndex = state.sections.findIndex((entry) => entry.name === FUTURE_PLANS_NAME);
-  if (futureIndex === -1) {
-    state.sections.push(section);
-  } else {
-    state.sections.splice(futureIndex, 0, section);
-  }
-  renderSections();
-  markDirty();
-}
-
-function addChecklistItem() {
-  state.items.push({
-    uid: nextItemId(),
-    id: "",
-    label: "",
-    section: "",
-    group: "",
-    hint: ""
-  });
-  renderChecklist();
-  markDirty();
-}
-
-function buildSchemaFromState() {
-  const trimmedSections = [];
-  const seenSections = new Set();
-
-  state.sections.forEach((section) => {
-    const trimmed = typeof section.name === "string" ? section.name.trim() : "";
-    if (!trimmed || trimmed.toLowerCase() === "arse_cover_notes") return;
-    if (trimmed === FUTURE_PLANS_NAME) return;
-    if (seenSections.has(trimmed)) return;
-    seenSections.add(trimmed);
-    trimmedSections.push(trimmed);
-  });
-
-  trimmedSections.push(FUTURE_PLANS_NAME);
-
-  const items = [];
-  const seenIds = new Set();
-  state.items.forEach((item) => {
-    const copy = { ...item };
-    delete copy.uid;
-    const id = copy.id != null ? String(copy.id).trim() : "";
-    const label = copy.label != null ? String(copy.label).trim() : "";
-    if (!id || !label || seenIds.has(id)) return;
-    seenIds.add(id);
-    copy.id = id;
-    copy.label = label;
-    copy.group = copy.group != null ? String(copy.group).trim() : "";
-    copy.hint = copy.hint != null ? String(copy.hint).trim() : "";
-    const section = copy.section != null ? String(copy.section).trim() : "";
-    copy.section = section;
-    if (section) {
-      copy.depotSection = section;
-    } else {
-      delete copy.depotSection;
+  function render() {
+    if (sectionsInput) {
+      sectionsInput.value = JSON.stringify(current.sections, null, 2);
     }
-    items.push(copy);
-  });
-
-  return {
-    sections: trimmedSections,
-    checklist: {
-      sectionsOrder: trimmedSections.slice(),
-      items
+    if (checklistInput) {
+      checklistInput.value = JSON.stringify(current.checklist, null, 2);
     }
-  };
-}
-
-async function handleSave() {
-  try {
-    const schema = buildSchemaFromState();
-    const saved = saveSchema(schema);
-    applySchema(saved);
-    clearDirty();
-    setStatus("Settings saved to this device.", "success");
-  } catch (err) {
-    console.error(err);
-    setStatus("Failed to save settings.", "error");
-  }
-}
-
-async function handleReload({ silent = false } = {}) {
-  try {
-    const schema = await loadSchema();
-    applySchema(schema);
-    if (!silent) {
-      setStatus("Reloaded saved settings.", "muted");
+    if (summaryEl) {
+      const countSections = (current.sections || []).length;
+      const countItems = (current.checklist?.items || []).length;
+      const firstSections = (current.sections || []).slice(0, 6);
+      summaryEl.innerHTML = `
+        <p><strong>Sections:</strong> ${countSections}</p>
+        <p>${firstSections.map((s) => `• ${s}`).join("<br>") || "(none)"}</p>
+        <p style="margin-top:0.5rem;"><strong>Checklist items:</strong> ${countItems}</p>
+      `;
     }
-    return true;
-  } catch (err) {
-    console.error(err);
-    setStatus("Failed to reload settings.", "error");
-    return false;
   }
-}
 
-async function handleReset() {
-  try {
-    if (!defaultSchema || !Array.isArray(defaultSchema.sections)) {
-      defaultSchema = await getDefaultSchema();
+  function parseJsonOrAlert(textarea, label) {
+    try {
+      const value = JSON.parse(textarea.value || "null");
+      return value;
+    } catch (err) {
+      alert(`Invalid JSON in ${label}: ${err.message}`);
+      throw err;
     }
-    applySchema(defaultSchema);
-    markDirty("Defaults loaded. Save to apply them.");
-  } catch (err) {
-    console.error(err);
-    setStatus("Failed to load defaults.", "error");
   }
-}
 
-async function clearOverrides() {
-  try {
-    STORAGE_KEYS_TO_CLEAR.forEach((key) => {
-      localStorage.removeItem(key);
+  if (saveSectionsBtn && sectionsInput) {
+    saveSectionsBtn.addEventListener("click", async () => {
+      const rawSections = parseJsonOrAlert(sectionsInput, "Sections");
+      const next = {
+        sections: rawSections,
+        checklist: current.checklist
+      };
+      current = saveSchema(next);
+      render();
+      alert("Sections saved.");
     });
-    const reloaded = await handleReload({ silent: true });
-    if (reloaded) {
-      setStatus("Local overrides cleared.", "success");
-    }
-  } catch (err) {
-    console.error(err);
-    setStatus("Failed to clear local overrides.", "error");
   }
-}
 
-async function init() {
-  setStatus("Loading settings…", "muted");
-  try {
-    defaultSchema = await getDefaultSchema();
-    const schema = await loadSchema();
-    applySchema(schema);
-    setStatus("Settings loaded.", "muted");
-  } catch (err) {
-    console.error(err);
-    setStatus("Failed to load settings.", "error");
+  if (resetSectionsBtn) {
+    resetSectionsBtn.addEventListener("click", async () => {
+      const defaults = await getDefaultSchema();
+      current = saveSchema({
+        sections: defaults.sections,
+        checklist: current.checklist
+      });
+      render();
+      alert("Sections reset to defaults.");
+    });
   }
+
+  if (saveChecklistBtn && checklistInput) {
+    saveChecklistBtn.addEventListener("click", async () => {
+      const rawChecklist = parseJsonOrAlert(checklistInput, "Checklist");
+      const next = {
+        sections: current.sections,
+        checklist: rawChecklist
+      };
+      current = saveSchema(next);
+      render();
+      alert("Checklist saved.");
+    });
+  }
+
+  if (resetChecklistBtn) {
+    resetChecklistBtn.addEventListener("click", async () => {
+      const defaults = await getDefaultSchema();
+      current = saveSchema({
+        sections: current.sections,
+        checklist: defaults.checklist
+      });
+      render();
+      alert("Checklist reset to defaults.");
+    });
+  }
+
+  if (resetAllBtn) {
+    resetAllBtn.addEventListener("click", async () => {
+      if (!confirm("Reset sections and checklist to defaults?")) return;
+      const defaults = await getDefaultSchema();
+      current = saveSchema(defaults);
+      render();
+      alert("Schema reset to defaults.");
+    });
+  }
+
+  if (backBtn) {
+    backBtn.addEventListener("click", () => {
+      window.location.href = "index.html";
+    });
+  }
+
+  render();
 }
 
-if (addSectionBtn) {
-  addSectionBtn.addEventListener("click", () => {
-    addSection();
+document.addEventListener("DOMContentLoaded", () => {
+  initialise().catch((err) => {
+    console.error("Failed to initialise settings page", err);
+    alert("Failed to load schema. See console for details.");
   });
-}
-
-if (addItemBtn) {
-  addItemBtn.addEventListener("click", () => {
-    addChecklistItem();
-  });
-}
-
-if (saveBtn) {
-  saveBtn.addEventListener("click", () => {
-    handleSave();
-  });
-}
-
-if (reloadBtn) {
-  reloadBtn.addEventListener("click", () => {
-    handleReload();
-  });
-}
-
-if (resetBtn) {
-  resetBtn.addEventListener("click", () => {
-    handleReset();
-  });
-}
-
-if (clearBtn) {
-  clearBtn.addEventListener("click", () => {
-    clearOverrides();
-  });
-}
-
-init();
+});

--- a/settings.html
+++ b/settings.html
@@ -291,44 +291,61 @@
   </style>
 </head>
 <body>
-  <main>
-    <header>
-      <a href="index.html" class="back-link">← Back to notes</a>
-      <h1>Depot settings</h1>
-      <p>Configure Depot section names and checklist items. Changes are stored in this browser only.</p>
-    </header>
+  <header style="background:#0f172a;color:#fff;padding:14px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px;">
+    <h1 style="margin:0;font-size:1.05rem;">Survey Brain – Settings</h1>
+    <button id="backBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+      Back to app
+    </button>
+  </header>
 
-    <div class="status" data-status aria-live="polite"></div>
-
-    <section>
-      <header>
-        <h2>Depot sections</h2>
-        <p>Edit the section names and order. “Future plans” is kept automatically at the end.</p>
-      </header>
-      <div data-sections-list class="stack"></div>
-      <div class="section-actions">
-        <button type="button" data-add-section>Add section</button>
-      </div>
+  <main style="padding:14px;display:flex;flex-direction:column;gap:14px;max-width:1100px;margin:0 auto;">
+    <section style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;">
+      <h2 style="margin:0 0 6px;font-size:.85rem;">Depot schema summary</h2>
+      <div id="schemaSummary" style="font-size:.72rem;color:#475569;"></div>
     </section>
 
-    <section>
-      <header>
-        <h2>Checklist items</h2>
-        <p>Set the ID, label, and optional metadata for checklist items. Items with empty ID or label are ignored when saved.</p>
-      </header>
-      <div data-checklist-list class="stack"></div>
-      <div class="section-actions">
-        <button type="button" data-add-item>Add checklist item</button>
+    <section style="display:grid;grid-template-columns:1fr 1fr;gap:14px;">
+      <div style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;display:flex;flex-direction:column;gap:6px;">
+        <h2 style="margin:0 0 4px;font-size:.8rem;">Sections</h2>
+        <p style="margin:0 0 6px;font-size:.7rem;color:#64748b;">
+          Edit the list of depot note sections as JSON. Normally this is an array of section names:
+          <code>["Needs", "Working at heights", ...]</code>.
+          "Future plans" will always be added as the last section automatically.
+        </p>
+        <textarea id="sectionsJson" style="width:100%;min-height:180px;border-radius:10px;border:1px solid #cbd5e1;padding:8px 9px;font-size:.72rem;"></textarea>
+        <div style="display:flex;gap:8px;margin-top:6px;">
+          <button id="saveSectionsBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+            Save sections
+          </button>
+          <button id="resetSectionsBtn" style="border:none;background:#e5e7eb;color:#0f172a;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+            Reset sections to defaults
+          </button>
+        </div>
+      </div>
+
+      <div style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;display:flex;flex-direction:column;gap:6px;">
+        <h2 style="margin:0 0 4px;font-size:.8rem;">Checklist</h2>
+        <p style="margin:0 0 6px;font-size:.7rem;color:#64748b;">
+          Edit the checklist configuration as JSON. This should be an object like:
+          <code>{ "sectionsOrder": [...], "items": [...] }</code>.
+          Items are the same shape used by the app (id, label, section, group, hint, etc).
+        </p>
+        <textarea id="checklistJson" style="width:100%;min-height:180px;border-radius:10px;border:1px solid #cbd5e1;padding:8px 9px;font-size:.72rem;"></textarea>
+        <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:6px;">
+          <button id="saveChecklistBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+            Save checklist
+          </button>
+          <button id="resetChecklistBtn" style="border:none;background:#e5e7eb;color:#0f172a;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+            Reset checklist to defaults
+          </button>
+          <button id="resetAllBtn" style="border:none;background:#b91c1c;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
+            Reset ALL to defaults
+          </button>
+        </div>
       </div>
     </section>
-
-    <div class="actions">
-      <button type="button" data-save>Save changes</button>
-      <button type="button" class="secondary" data-reload>Reload saved</button>
-      <button type="button" class="secondary" data-reset>Reset to defaults</button>
-      <button type="button" class="danger" data-clear>Clear local overrides</button>
-    </div>
   </main>
+
   <script type="module" src="./js/settingsPage.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the settings controller to load and persist the normalised schema using the new schema module
- replace the interactive list UI with a simpler JSON editor backed by the schema helpers
- update settings.html layout to present the JSON editors, schema summary, and wiring to the module script

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a68fde20832c897a14d9ae7c0b25)