### PR TITLE
Add schema import/export controls to Depot sections settings

### DIFF
--- a/js/settingsSections.js
+++ b/js/settingsSections.js
@@ -1,0 +1,456 @@
+const SECTION_STORAGE_KEY = "depot.sectionSchema";
+const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
+const FUTURE_PLANS_NAME = "Future plans";
+const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
+const DEFAULT_SCHEMA_URL = "./depot.output.schema.json";
+
+let editableNames = [];
+let defaultNames = [];
+
+function $(id) {
+  return document.getElementById(id);
+}
+
+function escapeHtml(value) {
+  return String(value || "").replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+}
+
+function safeParse(json, fallback) {
+  try {
+    if (!json || typeof json !== "string") return fallback;
+    return JSON.parse(json);
+  } catch (err) {
+    console.warn("Failed to parse JSON", err);
+    return fallback;
+  }
+}
+
+function normaliseSectionNames(input) {
+  if (!input) return [];
+
+  const asArray = (value) => {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === "object" && Array.isArray(value.sections)) {
+      return value.sections;
+    }
+    return [];
+  };
+
+  const entries = asArray(input);
+  const names = [];
+  const seen = new Set();
+
+  entries.forEach((entry) => {
+    if (!entry) return;
+    let name = "";
+    if (typeof entry === "string") {
+      name = entry;
+    } else if (typeof entry === "object") {
+      const candidate = entry.name ?? entry.section ?? entry.title ?? entry.heading;
+      if (typeof candidate === "string") {
+        name = candidate;
+      }
+    }
+    const trimmed = String(name || "").trim();
+    if (!trimmed || seen.has(trimmed) || trimmed.toLowerCase() === "arse_cover_notes") {
+      return;
+    }
+    seen.add(trimmed);
+    names.push(trimmed);
+  });
+
+  return names;
+}
+
+function dedupeAndClean(names) {
+  const seen = new Set();
+  const cleaned = [];
+  names.forEach((raw) => {
+    const trimmed = String(raw || "").trim();
+    if (!trimmed || trimmed === FUTURE_PLANS_NAME) return;
+    if (trimmed.toLowerCase() === "arse_cover_notes") return;
+    if (seen.has(trimmed)) return;
+    seen.add(trimmed);
+    cleaned.push(trimmed);
+  });
+  return cleaned;
+}
+
+function getSanitisedNamesFromState(includeFuture = true) {
+  const cleaned = dedupeAndClean(editableNames);
+  if (includeFuture) {
+    cleaned.push(FUTURE_PLANS_NAME);
+  }
+  return cleaned;
+}
+
+function setStatus(message, type = "") {
+  const statusEl = $("sectionsStatus");
+  if (!statusEl) return;
+  statusEl.textContent = message || "";
+  statusEl.classList.remove("status--success", "status--error");
+  if (type === "success") {
+    statusEl.classList.add("status--success");
+  } else if (type === "error") {
+    statusEl.classList.add("status--error");
+  }
+}
+
+function renderSummary() {
+  const summaryEl = $("sectionSummary");
+  if (!summaryEl) return;
+  const names = getSanitisedNamesFromState(true);
+  const total = names.length;
+  const preview = names.slice(0, 8);
+  const remaining = total - preview.length;
+
+  const chips = preview
+    .map((name) => `<span class="summary-chip">${escapeHtml(name)}</span>`)
+    .join("");
+
+  summaryEl.innerHTML = `
+    <div><strong>Total sections:</strong> ${total}</div>
+    <div class="summary-chips">${chips || '<span class="summary-chip">(none)</span>'}</div>
+    ${remaining > 0 ? `<div class="summary-note">+${remaining} more</div>` : ""}
+  `;
+}
+
+function moveItem(arr, from, to) {
+  if (from === to) return;
+  if (from < 0 || from >= arr.length) return;
+  if (to < 0 || to >= arr.length) return;
+  const [item] = arr.splice(from, 1);
+  arr.splice(to, 0, item);
+}
+
+function renderSectionRows(focusIndex = null) {
+  const listEl = $("sectionsList");
+  if (!listEl) return;
+
+  listEl.innerHTML = "";
+  const namesForUi = [...editableNames, FUTURE_PLANS_NAME];
+
+  namesForUi.forEach((name, idx) => {
+    const isFuture = idx === namesForUi.length - 1;
+
+    const row = document.createElement("div");
+    row.className = "section-row";
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = name;
+    input.placeholder = "Section name";
+    input.disabled = isFuture;
+    input.dataset.future = isFuture ? "1" : "0";
+
+    if (!isFuture) {
+      input.addEventListener("input", (event) => {
+        editableNames[idx] = event.target.value;
+        renderSummary();
+      });
+    }
+
+    const controls = document.createElement("div");
+    controls.className = "section-controls";
+
+    const upBtn = document.createElement("button");
+    upBtn.type = "button";
+    upBtn.textContent = "↑";
+    upBtn.disabled = idx === 0;
+    upBtn.addEventListener("click", () => {
+      if (idx === 0) return;
+      moveItem(editableNames, idx, idx - 1);
+      renderSectionRows(idx - 1);
+    });
+
+    const downBtn = document.createElement("button");
+    downBtn.type = "button";
+    downBtn.textContent = "↓";
+    downBtn.disabled = isFuture || idx === namesForUi.length - 2;
+    downBtn.addEventListener("click", () => {
+      if (isFuture || idx === namesForUi.length - 2) return;
+      moveItem(editableNames, idx, idx + 1);
+      renderSectionRows(idx + 1);
+    });
+
+    const deleteBtn = document.createElement("button");
+    deleteBtn.type = "button";
+    deleteBtn.textContent = "Delete";
+    deleteBtn.disabled = isFuture;
+    deleteBtn.addEventListener("click", () => {
+      editableNames.splice(idx, 1);
+      renderSectionRows(idx >= editableNames.length ? editableNames.length - 1 : idx);
+    });
+
+    controls.append(upBtn, downBtn, deleteBtn);
+    row.append(input, controls);
+    listEl.appendChild(row);
+
+    if (!isFuture && focusIndex != null && idx === focusIndex) {
+      requestAnimationFrame(() => {
+        input.focus();
+        input.select();
+      });
+    }
+  });
+
+  renderSummary();
+}
+
+function prepareState(names) {
+  editableNames = dedupeAndClean(Array.isArray(names) ? names : []);
+}
+
+async function loadDefaultNames() {
+  try {
+    const res = await fetch(DEFAULT_SCHEMA_URL, { cache: "no-store" });
+    if (!res.ok) throw new Error(`Failed to load defaults (${res.status})`);
+    const json = await res.json();
+    const names = normaliseSectionNames(json);
+    return dedupeAndClean(names);
+  } catch (err) {
+    console.warn("Failed to fetch default section schema", err);
+    return [];
+  }
+}
+
+function loadStoredNames() {
+  const keys = [SECTION_STORAGE_KEY, LEGACY_SECTION_STORAGE_KEY];
+  for (const key of keys) {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) continue;
+      const parsed = safeParse(raw, null);
+      if (!parsed) continue;
+      const names = normaliseSectionNames(parsed);
+      if (names.length) {
+        return dedupeAndClean(names);
+      }
+    } catch (err) {
+      console.warn("Failed to read stored section schema override", err);
+    }
+  }
+  return [];
+}
+
+function saveNamesToLocalStorage(names) {
+  const cleaned = names
+    .map((n) => String(n || "").trim())
+    .filter((n) => n && n.toLowerCase() !== "arse_cover_notes");
+
+  const final = [];
+  cleaned.forEach((name, idx) => {
+    final.push({
+      name,
+      description: name === FUTURE_PLANS_NAME ? FUTURE_PLANS_DESCRIPTION : "",
+      order: idx + 1
+    });
+  });
+
+  try {
+    localStorage.setItem(
+      SECTION_STORAGE_KEY,
+      JSON.stringify({ sections: final })
+    );
+    localStorage.removeItem(LEGACY_SECTION_STORAGE_KEY);
+  } catch (err) {
+    console.warn("Failed to save section schema override", err);
+    alert("Could not save sections – storage error.");
+    return null;
+  }
+
+  return final;
+}
+
+function buildSchemaFromNames(names) {
+  const final = saveNamesToLocalStorage(names);
+  if (!final) return null;
+  return { sections: final };
+}
+
+async function exportSchemaAsFile(names) {
+  const schema = buildSchemaFromNames(names);
+  if (!schema) return;
+
+  const pretty = JSON.stringify(schema, null, 2);
+  const blob = new Blob([pretty], { type: "application/json" });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const filename = `survey-brain-sections-${timestamp}.json`;
+  const file = new File([blob], filename, { type: "application/json" });
+
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      await navigator.share({ files: [file] });
+      return;
+    } catch (err) {
+      console.warn("Share failed, falling back to download", err);
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+async function importSchemaFromFile(file) {
+  if (!file) return null;
+  try {
+    const text = await file.text();
+    const json = safeParse(text, null);
+    if (!json) {
+      alert("Selected file is not valid JSON.");
+      return null;
+    }
+    const names = normaliseSectionNames(json);
+    if (!names.length) {
+      alert("No valid sections found in this file.");
+      return null;
+    }
+    const cleaned = names.filter((n) => n !== FUTURE_PLANS_NAME);
+    cleaned.push(FUTURE_PLANS_NAME);
+    saveNamesToLocalStorage(cleaned);
+    return cleaned;
+  } catch (err) {
+    console.error("Failed to import schema file", err);
+    alert("Failed to read schema file.");
+    return null;
+  }
+}
+
+async function initSettingsPage() {
+  const addSectionBtn = $("addSectionBtn");
+  const saveSectionsBtn = $("saveSectionsBtn");
+  const resetSectionsBtn = $("resetSectionsBtn");
+  const clearOverrideBtn = $("clearOverrideBtn");
+  const exportSchemaBtn = $("exportSchemaBtn");
+  const importSchemaBtn = $("importSchemaBtn");
+  const importSchemaInput = $("importSchemaInput");
+  const backBtn = $("backBtn");
+
+  defaultNames = await loadDefaultNames();
+  const storedNames = loadStoredNames();
+  const initial = storedNames.length ? storedNames : defaultNames;
+  prepareState(initial);
+
+  renderSectionRows();
+  setStatus("", "");
+
+  if (backBtn) {
+    backBtn.addEventListener("click", () => {
+      window.location.href = "index.html";
+    });
+  }
+
+  if (addSectionBtn) {
+    addSectionBtn.addEventListener("click", () => {
+      editableNames.push("");
+      renderSectionRows(editableNames.length - 1);
+      setStatus("Added a new section. Don't forget to save.");
+    });
+  }
+
+  if (saveSectionsBtn) {
+    saveSectionsBtn.addEventListener("click", () => {
+      const namesForSave = getSanitisedNamesFromState(true);
+      if (!namesForSave.length) {
+        alert("Add at least one section before saving.");
+        setStatus("No sections to save.", "error");
+        return;
+      }
+      const saved = saveNamesToLocalStorage(namesForSave);
+      if (!saved) return;
+      editableNames = saved
+        .map((entry) => entry.name)
+        .filter((name) => name !== FUTURE_PLANS_NAME);
+      renderSectionRows();
+      setStatus("Sections saved to this device.", "success");
+    });
+  }
+
+  if (resetSectionsBtn) {
+    resetSectionsBtn.addEventListener("click", () => {
+      const baseline = defaultNames.length ? defaultNames : [];
+      prepareState(baseline);
+      const namesForSave = getSanitisedNamesFromState(true);
+      saveNamesToLocalStorage(namesForSave);
+      renderSectionRows();
+      setStatus("Sections reset to defaults.", "success");
+    });
+  }
+
+  if (clearOverrideBtn) {
+    clearOverrideBtn.addEventListener("click", () => {
+      try {
+        localStorage.removeItem(SECTION_STORAGE_KEY);
+        localStorage.removeItem(LEGACY_SECTION_STORAGE_KEY);
+      } catch (err) {
+        console.warn("Failed to clear section override", err);
+      }
+      prepareState(defaultNames);
+      renderSectionRows();
+      setStatus("Override cleared for this device.", "success");
+    });
+  }
+
+  if (exportSchemaBtn) {
+    exportSchemaBtn.addEventListener("click", () => {
+      const namesForExport = getSanitisedNamesFromState(false);
+      namesForExport.push(FUTURE_PLANS_NAME);
+      exportSchemaAsFile(namesForExport)
+        .then(() => {
+          setStatus("Schema exported.", "success");
+        })
+        .catch((err) => {
+          console.error("Export failed", err);
+          alert("Failed to export schema.");
+          setStatus("Failed to export schema.", "error");
+        });
+    });
+  }
+
+  if (importSchemaBtn && importSchemaInput) {
+    importSchemaBtn.addEventListener("click", () => {
+      importSchemaInput.click();
+    });
+
+    importSchemaInput.addEventListener("change", async (event) => {
+      const file = event.target.files && event.target.files[0];
+      if (!file) return;
+      const importedNames = await importSchemaFromFile(file);
+      importSchemaInput.value = "";
+      if (!importedNames || !importedNames.length) return;
+      editableNames = importedNames.filter((n) => n !== FUTURE_PLANS_NAME);
+      renderSectionRows();
+      alert("Schema imported and saved to this device.");
+      setStatus("Schema imported and saved to this device.", "success");
+    });
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  initSettingsPage().catch((err) => {
+    console.error("Failed to initialise settings page", err);
+    alert("Failed to load section editor. See console for details.");
+  });
+});

--- a/settings.html
+++ b/settings.html
@@ -12,9 +12,11 @@
       --border: #d9e0eb;
       --accent: #2563eb;
       --accent-dark: #1d4ed8;
+      --primary: #0f766e;
+      --primary-dark: #0d5c55;
       --danger: #b91c1c;
       --text-muted: #64748b;
-      --radius: 14px;
+      --radius: 16px;
     }
 
     * {
@@ -27,13 +29,52 @@
       background: var(--bg);
       color: #0f172a;
       min-height: 100vh;
+    }
+
+    .page-shell {
+      width: min(960px, 100%);
+      margin: 0 auto;
+      padding: 32px 16px 48px;
       display: flex;
-      justify-content: center;
-      padding: 32px 16px;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .page-header {
+      background: #0f172a;
+      color: #fff;
+      padding: 16px 20px;
+      border-radius: var(--radius);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      box-shadow: 0 14px 28px rgba(15, 23, 42, 0.25);
+    }
+
+    .page-header h1 {
+      margin: 0;
+      font-size: 1.05rem;
+      letter-spacing: -0.01em;
+    }
+
+    .page-header button {
+      border: none;
+      background: var(--primary);
+      color: #fff;
+      border-radius: 999px;
+      padding: 6px 14px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    .page-header button:hover {
+      background: var(--primary-dark);
     }
 
     main {
-      width: min(960px, 100%);
       background: var(--card);
       border-radius: var(--radius);
       border: 1px solid var(--border);
@@ -44,64 +85,105 @@
       gap: 32px;
     }
 
-    header {
+    section.card {
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 18px;
     }
 
-    header h1 {
-      margin: 0;
-      font-size: 1.45rem;
-      letter-spacing: -0.01em;
-    }
-
-    header p {
-      margin: 0;
-      color: var(--text-muted);
-      font-size: 0.9rem;
-    }
-
-    a.back-link {
-      color: var(--accent);
-      text-decoration: none;
-      font-size: 0.85rem;
-    }
-
-    .status {
-      min-height: 1.2em;
-      font-size: 0.85rem;
-      color: var(--text-muted);
-    }
-
-    .status--success {
-      color: #047857;
-    }
-
-    .status--error {
-      color: var(--danger);
-    }
-
-    section {
+    section.card > header {
       display: flex;
       flex-direction: column;
-      gap: 16px;
-    }
-
-    section > header {
       gap: 6px;
     }
 
-    section > header h2 {
+    section.card > header h2 {
       margin: 0;
-      font-size: 1.05rem;
+      font-size: 1.1rem;
     }
 
-    section > header p {
+    section.card > header p {
       margin: 0;
-      font-size: 0.85rem;
+      font-size: 0.86rem;
       color: var(--text-muted);
-      line-height: 1.4;
+      line-height: 1.45;
+    }
+
+    .summary {
+      border: 1px solid #e2e8f0;
+      border-radius: 14px;
+      padding: 12px 14px;
+      background: #f8fafc;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      font-size: 0.82rem;
+      color: #334155;
+    }
+
+    .summary strong {
+      font-weight: 600;
+      color: #1e293b;
+    }
+
+    .summary-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .summary-chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 4px 10px;
+      border-radius: 999px;
+      background: rgba(37, 99, 235, 0.1);
+      color: #1d4ed8;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+
+    .summary-note {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .toolbar button {
+      border: none;
+      border-radius: 999px;
+      padding: 8px 16px;
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+      background: var(--primary);
+      color: #fff;
+    }
+
+    .toolbar button:hover {
+      background: var(--primary-dark);
+    }
+
+    .toolbar button.secondary {
+      background: #eef2ff;
+      color: var(--accent);
+      border: 1px solid rgba(37, 99, 235, 0.4);
+    }
+
+    .toolbar button.secondary:hover {
+      background: #dbeafe;
+      color: var(--accent-dark);
+    }
+
+    .toolbar button.danger {
+      background: var(--danger);
+      color: #fff;
     }
 
     .stack {
@@ -116,7 +198,7 @@
       align-items: center;
       background: #f8fafc;
       border: 1px solid #e2e8f0;
-      border-radius: 10px;
+      border-radius: 12px;
       padding: 12px;
     }
 
@@ -125,7 +207,7 @@
       border-radius: 8px;
       border: 1px solid #cbd5e1;
       padding: 8px 10px;
-      font-size: 0.9rem;
+      font-size: 0.92rem;
       background: #fff;
     }
 
@@ -154,198 +236,85 @@
       cursor: not-allowed;
     }
 
-    .section-actions {
-      display: flex;
-      justify-content: flex-start;
-    }
-
-    .section-actions button {
-      background: var(--accent);
-      border: none;
-      color: #fff;
-      padding: 8px 14px;
-      border-radius: 999px;
-      font-size: 0.82rem;
-      cursor: pointer;
-    }
-
-    .checklist-card {
-      border: 1px solid #e2e8f0;
-      border-radius: 12px;
-      padding: 16px;
-      background: #f8fafc;
-      display: grid;
-      gap: 12px;
-    }
-
-    .checklist-fields {
-      display: grid;
-      gap: 12px;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    }
-
-    .checklist-fields label {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      color: var(--text-muted);
-    }
-
-    .checklist-fields input,
-    .checklist-fields select,
-    .checklist-fields textarea {
-      font-size: 0.85rem;
-      padding: 8px 10px;
-      border-radius: 8px;
-      border: 1px solid #cbd5e1;
-      background: #fff;
-      color: #0f172a;
-    }
-
-    .checklist-fields textarea {
-      resize: vertical;
-      min-height: 56px;
-    }
-
-    .checklist-actions {
-      display: flex;
-      gap: 8px;
-      justify-content: flex-end;
-    }
-
-    .checklist-actions button {
-      border: none;
-      background: #e2e8f0;
-      color: #0f172a;
-      padding: 6px 10px;
-      border-radius: 8px;
-      font-size: 0.8rem;
-      cursor: pointer;
-    }
-
-    .checklist-actions button:disabled {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
-
-    .checklist-actions button:last-child {
-      background: var(--danger);
-      color: #fff;
-    }
-
     .list-empty {
       font-size: 0.85rem;
       color: var(--text-muted);
       font-style: italic;
     }
 
-    .actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
+    .status {
+      min-height: 1.2em;
+      font-size: 0.85rem;
+      color: var(--text-muted);
     }
 
-    .actions button {
-      border: none;
-      border-radius: 999px;
-      padding: 10px 18px;
-      font-size: 0.9rem;
-      font-weight: 600;
-      cursor: pointer;
-      background: var(--accent);
-      color: #fff;
-      transition: background 0.2s ease;
+    .status--success {
+      color: #047857;
     }
 
-    .actions button:hover {
-      background: var(--accent-dark);
-    }
-
-    .actions button.secondary {
-      background: transparent;
-      border: 1px solid var(--accent);
-      color: var(--accent);
-    }
-
-    .actions button.danger {
-      background: var(--danger);
-      color: #fff;
+    .status--error {
+      color: var(--danger);
     }
 
     @media (max-width: 720px) {
-      body {
-        padding: 16px;
+      .page-shell {
+        padding: 20px 12px 32px;
       }
 
-      main {
-        padding: 20px;
+      .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
       }
 
-      .checklist-fields {
-        grid-template-columns: 1fr;
+      .toolbar {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .toolbar button {
+        width: 100%;
+        justify-content: center;
       }
     }
   </style>
 </head>
 <body>
-  <header style="background:#0f172a;color:#fff;padding:14px 16px;display:flex;align-items:center;justify-content:space-between;gap:12px;">
-    <h1 style="margin:0;font-size:1.05rem;">Survey Brain – Settings</h1>
-    <button id="backBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-      Back to app
-    </button>
-  </header>
+  <div class="page-shell">
+    <header class="page-header">
+      <h1>Survey Brain – Settings</h1>
+      <button id="backBtn" type="button">Back to app</button>
+    </header>
 
-  <main style="padding:14px;display:flex;flex-direction:column;gap:14px;max-width:1100px;margin:0 auto;">
-    <section style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;">
-      <h2 style="margin:0 0 6px;font-size:.85rem;">Depot schema summary</h2>
-      <div id="schemaSummary" style="font-size:.72rem;color:#475569;"></div>
-    </section>
+    <main>
+      <section class="card">
+        <header>
+          <h2>Depot section order</h2>
+          <p>
+            Arrange the sections used when exporting Depot notes. Changes are saved only on this
+            device, but you can export and import your personal schema as needed.
+          </p>
+        </header>
 
-    <section style="display:grid;grid-template-columns:1fr 1fr;gap:14px;">
-      <div style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;display:flex;flex-direction:column;gap:6px;">
-        <h2 style="margin:0 0 4px;font-size:.8rem;">Sections</h2>
-        <p style="margin:0 0 6px;font-size:.7rem;color:#64748b;">
-          Edit the list of depot note sections as JSON. Normally this is an array of section names:
-          <code>["Needs", "Working at heights", ...]</code>.
-          "Future plans" will always be added as the last section automatically.
-        </p>
-        <textarea id="sectionsJson" style="width:100%;min-height:180px;border-radius:10px;border:1px solid #cbd5e1;padding:8px 9px;font-size:.72rem;"></textarea>
-        <div style="display:flex;gap:8px;margin-top:6px;">
-          <button id="saveSectionsBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-            Save sections
-          </button>
-          <button id="resetSectionsBtn" style="border:none;background:#e5e7eb;color:#0f172a;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-            Reset sections to defaults
-          </button>
+        <div id="sectionSummary" class="summary"></div>
+
+        <div class="toolbar">
+          <button id="addSectionBtn">+ Add section</button>
+          <button id="saveSectionsBtn">Save to this device</button>
+          <button id="exportSchemaBtn" class="secondary">Export JSON</button>
+          <button id="importSchemaBtn" class="secondary">Import JSON</button>
+          <button id="resetSectionsBtn" class="secondary">Reset to defaults</button>
+          <button id="clearOverrideBtn" class="danger">Clear override on this device</button>
+          <input id="importSchemaInput" type="file" accept="application/json" style="display:none;" />
         </div>
-      </div>
 
-      <div style="background:#ffffff;border:1px solid #d4dbe5;border-radius:16px;padding:12px 14px 10px;display:flex;flex-direction:column;gap:6px;">
-        <h2 style="margin:0 0 4px;font-size:.8rem;">Checklist</h2>
-        <p style="margin:0 0 6px;font-size:.7rem;color:#64748b;">
-          Edit the checklist configuration as JSON. This should be an object like:
-          <code>{ "sectionsOrder": [...], "items": [...] }</code>.
-          Items are the same shape used by the app (id, label, section, group, hint, etc).
-        </p>
-        <textarea id="checklistJson" style="width:100%;min-height:180px;border-radius:10px;border:1px solid #cbd5e1;padding:8px 9px;font-size:.72rem;"></textarea>
-        <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:6px;">
-          <button id="saveChecklistBtn" style="border:none;background:#0f766e;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-            Save checklist
-          </button>
-          <button id="resetChecklistBtn" style="border:none;background:#e5e7eb;color:#0f172a;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-            Reset checklist to defaults
-          </button>
-          <button id="resetAllBtn" style="border:none;background:#b91c1c;color:#fff;border-radius:999px;padding:6px 14px;font-size:.7rem;font-weight:600;cursor:pointer;">
-            Reset ALL to defaults
-          </button>
-        </div>
-      </div>
-    </section>
-  </main>
+        <div id="sectionsList" class="stack"></div>
 
-  <script type="module" src="./js/settingsPage.js"></script>
+        <p id="sectionsStatus" class="status"></p>
+      </section>
+    </main>
+  </div>
+
+  <script type="module" src="./js/settingsSections.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign the Depot settings page card to focus on the section-order editor with a new toolbar and status summary
- add a dedicated settingsSections module that sanitises section names, renders the editor UI, and saves overrides to localStorage
- support exporting the current schema to a JSON file or navigator.share payload and importing overrides from selected JSON files

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ced62f60832cad876878ac294a10)