### PR TITLE
Document schema assumption for refreshUiFromState

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -883,6 +883,8 @@ function renderChecklist(container, checkedIds, missingInfoFromServer) {
   }
 }
 
+// NOTE: Assumes SECTION_SCHEMA has been populated via loadStaticConfig()/ensureSectionSchema().
+// This allows placeholder sections (schema headings) to appear before any worker output arrives.
 function refreshUiFromState() {
   // 1) Customer summary
   customerSummaryEl.textContent = lastCustomerSummary || "(none)";


### PR DESCRIPTION
## Summary
- add inline documentation around `refreshUiFromState` to remind that placeholder sections rely on the schema being loaded first

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918ef295b10832caf791dd861e47c22)