### PR TITLE
feat: keep schema order visible and add worker debug

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,10 @@
       white-space: pre-wrap;
       font-size: .64rem;
     }
+    .section-item pre.placeholder {
+      color: var(--muted);
+      font-style: italic;
+    }
     .statusbar {
       font-size: .6rem;
       color: var(--muted);
@@ -204,6 +208,23 @@
       padding: 6px 8px;
       border-radius: 8px;
       font-weight: 500;
+    }
+    .debug-output {
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 10px;
+      padding: 8px;
+      font-size: .62rem;
+      max-height: 220px;
+      overflow: auto;
+      margin: 0;
+      white-space: pre-wrap;
+      font-family: ui-monospace, SFMono-Regular, SFMono, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+    .debug-output.empty {
+      background: #f8fafc;
+      color: var(--muted);
+      font-style: italic;
     }
   </style>
 </head>
@@ -279,6 +300,13 @@
       <div id="sectionsList" class="sections-list">
         <span class="small">No sections yet.</span>
       </div>
+    </div>
+    <div class="card">
+      <div class="card-title">
+        Worker debug
+        <span class="small">Raw payload</span>
+      </div>
+      <pre id="workerDebug" class="debug-output empty">No worker response yet.</pre>
     </div>
   </section>
 

--- a/js/schema.js
+++ b/js/schema.js
@@ -3,8 +3,6 @@
 const SECTION_STORAGE_KEY = "depot.sectionSchema";
 const LEGACY_SECTION_STORAGE_KEY = "surveybrain-schema";
 const CHECKLIST_STORAGE_KEY = "depot.checklistConfig";
-const FUTURE_PLANS_NAME = "Future plans";
-const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";
 
 // Optional unified key for future versions (not required by the app yet)
 const LS_SCHEMA_KEY = "depot.notesSchema.v1";
@@ -69,20 +67,7 @@ function sanitiseSectionSchema(input) {
     });
   });
 
-  // Ensure Future plans exists and is last
-  let withoutFuture = unique.filter((entry) => entry.name !== FUTURE_PLANS_NAME);
-  let future = unique.find((entry) => entry.name === FUTURE_PLANS_NAME);
-  if (!future) {
-    future = {
-      name: FUTURE_PLANS_NAME,
-      description: FUTURE_PLANS_DESCRIPTION,
-      order: withoutFuture.length + 1
-    };
-  } else if (!future.description) {
-    future = { ...future, description: FUTURE_PLANS_DESCRIPTION };
-  }
-
-  const final = [...withoutFuture, future].map((entry, idx) => ({
+  const final = unique.map((entry, idx) => ({
     name: entry.name,
     description: entry.description || "",
     order: idx + 1
@@ -226,10 +211,6 @@ export function normaliseSchema(raw, fallback) {
       .filter((s) => s && s.toLowerCase() !== "arse_cover_notes");
   }
 
-  // Ensure Future plans exists and is last
-  sections = sections.filter((s) => s !== FUTURE_PLANS_NAME);
-  sections.push(FUTURE_PLANS_NAME);
-
   // Normalise checklist
   let checklist = raw.checklist;
   if (!checklist || typeof checklist !== "object") {
@@ -308,7 +289,7 @@ export function saveSchema(schema) {
   // Sections format: an array of { name, description, order }
   const legacySections = normalised.sections.map((name, idx) => ({
     name,
-    description: name === FUTURE_PLANS_NAME ? FUTURE_PLANS_DESCRIPTION : "",
+    description: "",
     order: idx + 1
   }));
   try {


### PR DESCRIPTION
## Summary
- ensure the UI always renders sections in the schema-defined order and show placeholder text instead of fake bullets when a section has no notes yet
- add a worker debug panel so raw worker responses can be inspected directly from the app and reset it when sessions are cleared or restored
- stop forcing the "Future plans" section to the end when sanitising schemas so the configured order is preserved everywhere

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919755866d8832cbad7ceabe5aa724d)