### PR TITLE
Restore transcript from audio uploads

### DIFF
--- a/brain-worker.js
+++ b/brain-worker.js
@@ -134,7 +134,14 @@ async function handleAudio(request, env) {
       sectionHints: {},
       forceStructured: true
     });
-    return jsonResponse(result, 200);
+    return jsonResponse(
+      {
+        ...result,
+        transcript,
+        fullTranscript: transcript
+      },
+      200
+    );
   } catch (err) {
     console.error("handleAudio error:", err);
     return jsonResponse(

--- a/js/main.js
+++ b/js/main.js
@@ -1602,6 +1602,13 @@ async function sendAudio(blob) {
     }
     setWorkerDebugPayload(data);
     normaliseSectionsFromResponse(data, schemaSnapshot);
+    if (data.fullTranscript || data.transcript) {
+      const transcriptText = data.fullTranscript || data.transcript;
+      transcriptInput.value = transcriptText;
+      committedTranscript = transcriptText.trim();
+      lastSentTranscript = committedTranscript;
+      updateTranscriptDisplay();
+    }
     applyVoiceResult(data);
     setStatus("Audio processed.");
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure the `/audio` worker response echoes the generated transcript text
- populate the transcript input and display when an audio transcription is returned

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4ef75860832c94aae6b1d48e5613)