### PR TITLE
Remove recording completion popup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3097,10 +3097,10 @@ async function enhancedFinishLiveSession() {
     await originalFinishLiveSession();
   }
 
-  // Show finish modal
-  setTimeout(() => {
-    showFinishSessionModal();
-  }, 500);
+  // Popup removed - recording will remain on main page
+  // setTimeout(() => {
+  //   showFinishSessionModal();
+  // }, 500);
 
   // Mark session as inactive
   localStorage.removeItem(SESSION_ACTIVE_KEY);


### PR DESCRIPTION
- Commented out showFinishSessionModal() call in enhancedFinishLiveSession()
- Recording transcript and data remain visible on main page
- Session completion still functions normally without popup interruption