### PR TITLE
Add TXT export format and audio file export options

### DIFF
--- a/index.html
+++ b/index.html
@@ -1000,6 +1000,30 @@
               <input type="radio" name="saveFormat" value="csv" id="saveFormatCSV">
               <span>CSV (spreadsheet format, no audio)</span>
             </label>
+            <label class="format-option-item">
+              <input type="radio" name="saveFormat" value="txt" id="saveFormatTXT">
+              <span>TXT (plain text format, no audio)</span>
+            </label>
+          </div>
+        </div>
+
+        <div class="save-section">
+          <h3>Audio export (optional):</h3>
+          <div class="save-options">
+            <label class="save-option-item">
+              <input type="checkbox" id="saveAudioWav" value="audio-wav">
+              <div class="option-details">
+                <span class="option-title">Save as WAV</span>
+                <span class="option-description">Export audio in WAV format</span>
+              </div>
+            </label>
+            <label class="save-option-item">
+              <input type="checkbox" id="saveAudioMp3" value="audio-mp3">
+              <div class="option-details">
+                <span class="option-title">Save as MP3/WebM</span>
+                <span class="option-description">Export audio in recorded format (WebM/MP4/M4A)</span>
+              </div>
+            </label>
           </div>
         </div>
 


### PR DESCRIPTION
- Added .txt format option to save menu alongside JSON and CSV
- Implemented plain text conversion for all save types (session, depot notes, AI notes, transcript)
- Added audio export options: WAV and native format (WebM/MP4/M4A)
- WAV export converts recorded audio using Web Audio API
- Native format export saves audio in originally recorded format
- Text exports provide clean, readable formatting with section headers