### PR TITLE
Fix summary modal button layout for mobile Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,6 +981,50 @@
       font-size: 0.8rem;
       line-height: 1.5;
     }
+
+    /* Mobile responsive styles for summary modal */
+    @media (max-width: 480px) {
+      .modal-content {
+        padding: 16px;
+        width: 98%;
+        max-height: 95vh;
+      }
+
+      .modal-header {
+        padding-bottom: 12px;
+        margin-bottom: 12px;
+      }
+
+      .modal-header h2 {
+        font-size: 1.1rem;
+      }
+
+      .summary-actions {
+        flex-direction: column;
+        gap: 8px;
+        justify-content: stretch;
+      }
+
+      .summary-actions button {
+        width: 100%;
+        padding: 14px 16px;
+        font-size: 0.9rem;
+        min-height: 44px; /* iOS recommended touch target */
+      }
+
+      .recommendation-card {
+        padding: 14px;
+      }
+
+      .select-system-btn {
+        min-height: 44px; /* iOS recommended touch target */
+      }
+
+      #generateSummaryBtn {
+        min-height: 44px;
+        padding: 12px 20px;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
- Add mobile-responsive media query for viewports <= 480px
- Stack summary action buttons vertically on mobile
- Ensure all buttons meet iOS touch target guidelines (44px min height)
- Reduce modal padding on mobile to maximize content space
- Fix overflow issue preventing buttons from being clickable on iPhone

Fixes issue where summary modal buttons were not accessible on iPhone Safari (387x657 viewport).