### PR TITLE
Disable automatic recording after session name confirmation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3191,10 +3191,10 @@ if (confirmSessionNameBtn) {
     hideSessionNameModal();
     markSessionActive();
 
-    // Now start the live session
-    if (originalStartLiveSession) {
-      originalStartLiveSession();
-    }
+    // Auto-recording disabled - user must manually click Start button
+    // if (originalStartLiveSession) {
+    //   originalStartLiveSession();
+    // }
   });
 }
 


### PR DESCRIPTION
Previously, the app would automatically start recording as soon as the user
confirmed a session name. This change removes that auto-start behavior,
requiring users to explicitly click the Start button to begin recording.

This gives users more control over when recording begins.