### PR TITLE
Add Tweak button to main page sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,6 +214,30 @@
       color: var(--muted);
       font-style: italic;
     }
+    .tweak-section-btn-main {
+      background: var(--accent-soft);
+      color: white;
+      border: none;
+      padding: 4px 10px;
+      border-radius: 6px;
+      font-size: 0.65rem;
+      font-weight: 600;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      transition: all 0.2s ease;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .tweak-section-btn-main:hover {
+      background: var(--accent-hover);
+      transform: translateY(-1px);
+      box-shadow: var(--shadow-sm);
+    }
+    .tweak-section-btn-main svg {
+      flex-shrink: 0;
+    }
     .statusbar {
       font-size: .6rem;
       color: var(--muted);

--- a/js/main.js
+++ b/js/main.js
@@ -1507,9 +1507,10 @@ function refreshUiFromState() {
 
   const sectionsToRender = resolved.length ? resolved : normaliseDepotSections([]);
   sectionsListEl.innerHTML = "";
-  sectionsToRender.forEach((sec) => {
+  sectionsToRender.forEach((sec, index) => {
     const div = document.createElement("div");
     div.className = "section-item";
+    div.dataset.sectionIndex = index;
     const plainTextRaw = typeof sec.plainText === "string" ? sec.plainText : "";
     const formattedPlain = plainTextRaw
       ? formatPlainTextForSection(sec.section, plainTextRaw).trim()
@@ -1520,11 +1521,32 @@ function refreshUiFromState() {
       ? `<p class="small" style="margin-top:3px;">${naturalLanguage}</p>`
       : "";
     div.innerHTML = `
-      <h4>${sec.section}</h4>
+      <div style="display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+        <h4 style="margin: 0;">${sec.section}</h4>
+        <button class="tweak-section-btn-main" data-section-index="${index}" title="Tweak this section with AI">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+          </svg>
+          Tweak
+        </button>
+      </div>
       <pre${preClassAttr}>${formattedPlain || "No bullets yet."}</pre>
       ${naturalMarkup}
     `;
     sectionsListEl.appendChild(div);
+  });
+
+  // Attach event listeners to tweak buttons
+  const tweakBtns = sectionsListEl.querySelectorAll('.tweak-section-btn-main');
+  tweakBtns.forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const index = parseInt(e.currentTarget.dataset.sectionIndex, 10);
+      const section = sectionsToRender[index];
+      if (section && window.showTweakModal) {
+        window.showTweakModal(section, index);
+      }
+    });
   });
 
   // 3) Parts + checklist

--- a/js/sendSections.js
+++ b/js/sendSections.js
@@ -70,7 +70,7 @@ function attachSectionEventListeners(container, sections) {
       const index = parseInt(e.currentTarget.dataset.sectionIndex, 10);
       const section = sections[index];
       if (section) {
-        showTweakModal(section, index);
+        window.showTweakModal(section, index);
       }
     });
   });
@@ -543,8 +543,9 @@ export function copyAllSections(sections) {
 
 /**
  * Show the tweak modal for a section
+ * Exposed globally for use by main.js
  */
-function showTweakModal(section, sectionIndex) {
+window.showTweakModal = function(section, sectionIndex) {
   // Create modal
   const modal = document.createElement('div');
   modal.className = 'tweak-modal-backdrop';


### PR DESCRIPTION
Enhanced the main page UI by adding Tweak buttons directly to each section under the processed transcript, making the feature more accessible.

Changes:

Frontend (js/main.js):
- Modified refreshUiFromState() to add Tweak button to each section
- Button appears next to section title in header row
- Added event listeners that trigger the tweak modal
- Stores section index for proper identification

UI/UX (index.html):
- Added .tweak-section-btn-main CSS class
- Compact button design (65% font size) to fit in section headers
- Purple gradient theme matching existing design
- Smooth hover effects with lift animation

Integration (js/sendSections.js):
- Exposed showTweakModal as global function (window.showTweakModal)
- Allows main.js to trigger the same modal used in slide-over
- Maintains consistent UX across both interfaces

User Experience:
- Tweak button now available on BOTH:
  1. Main page under processed transcript
  2. Send Sections slide-over
- Click Tweak → Enter instructions → AI improves section
- Updates sync across all views automatically