### PR TITLE
Fix what3words modal blocking page interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -1694,11 +1694,14 @@
       bottom: 0;
       background: rgba(0,0,0,0.6);
       z-index: 2000;
-      display: flex;
+      display: none;
       align-items: center;
       justify-content: center;
       padding: 20px;
       animation: fadeIn 0.2s ease;
+    }
+    .w3w-modal-backdrop.active {
+      display: flex;
     }
     .w3w-modal-backdrop.closing {
       animation: fadeOut 0.2s ease;


### PR DESCRIPTION
The what3words modal backdrop was set to display: flex by default,
which meant any modal instance would immediately block the entire
page with its z-index of 2000. This prevented all tiles and buttons
on the first page from working.

Fixed by:
- Setting .w3w-modal-backdrop to display: none by default
- Adding .w3w-modal-backdrop.active with display: flex
- This matches the pattern used by other modals in the app

The modal now only appears when explicitly shown via the .active class.