### PR TITLE
Add Anthropic API as fallback to OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Voice-notes capture tool for depot/site surveys. Free mode keeps everything in t
 - Free local dictation using the browser Web Speech API
 - Pro unlock via signed Ed25519 license tokens (local + Worker verification)
 - 20 second Pro recording limit with MediaRecorder capture
-- Cloudflare Worker proxy to OpenAI `gpt-4o-mini-transcribe`
+- Cloudflare Worker proxy to OpenAI or Anthropic for AI processing
+- Automatic fallback to Anthropic Claude if OpenAI fails
 - Integrated bug reporting system with email notifications via Mailchannels
 
 ## Quick start
@@ -29,9 +30,15 @@ Voice-notes capture tool for depot/site surveys. Free mode keeps everything in t
 3. **Configure and deploy the Worker**
    ```bash
    wrangler secret put OPENAI_API_KEY
+   wrangler secret put ANTHROPIC_API_KEY  # Optional: for fallback support
    wrangler deploy
    ```
    Update `ALLOWED_ORIGIN` (and optional additional origins) plus `PUBLIC_KEY_JWK_X` in `wrangler.toml`.
+
+   **Note:** You can configure either or both API keys:
+   - `OPENAI_API_KEY` only: Uses OpenAI exclusively
+   - `ANTHROPIC_API_KEY` only: Uses Anthropic Claude exclusively
+   - Both keys: Uses OpenAI by default, falls back to Anthropic if OpenAI fails
 
 4. **Host the web app**
    Serve `index.html` from GitHub Pages or your domain. Update in-file constants:

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,5 +6,6 @@ compatibility_date = "2024-11-08"
 # Lock this to your site origin(s) for security:
 ALLOWED_ORIGIN = "https://YOUR-DOMAIN.example"
 
-# Set your secret via:
+# Set your secrets via:
 #   wrangler secret put OPENAI_API_KEY
+#   wrangler secret put ANTHROPIC_API_KEY


### PR DESCRIPTION
This enhancement adds Anthropic Claude Sonnet 4.5 as a fallback AI provider to improve reliability and results.

Changes:
- Add callAnthropicChat() helper function for Anthropic Messages API
- Implement automatic fallback logic in callNotesModel() and tweakSectionWithAI()
- Support flexible configuration: OpenAI only, Anthropic only, or both with fallback
- Update wrangler.toml to document ANTHROPIC_API_KEY secret
- Update README with setup instructions for the new API key

When both API keys are configured:
1. System attempts OpenAI (GPT-4.1) first
2. If OpenAI fails, automatically falls back to Anthropic (Claude Sonnet 4.5)
3. Logs clearly indicate which provider was used and any failures

This improves system resilience and allows users to leverage the best of both AI providers.