### PR TITLE
Fix agent chat window display issue

### DIFF
--- a/js/agentMode.js
+++ b/js/agentMode.js
@@ -210,7 +210,7 @@ function updateSuggestionsUI() {
     return;
   }
 
-  panel.style.display = 'block';
+  panel.style.display = 'flex';
 
   const { critical, important, optional } = AGENT_STATE.suggestions;
   const hasAnySuggestions = critical.length > 0 || important.length > 0 || optional.length > 0;


### PR DESCRIPTION
Changed display style from 'block' to 'flex' in agentMode.js to match the CSS flexbox layout and other code references. This fixes the bug where only the panel header showed without the content area.