### PR TITLE
Convert agent popup to always-on tile replacing customer summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,38 +1050,22 @@
       }
     }
 
-    /* Agent Monitoring Panel */
-    .agent-panel {
-      position: fixed;
-      top: 80px;
-      right: 20px;
-      width: 350px;
-      max-height: calc(100vh - 100px);
-      background: white;
-      border: 2px solid var(--accent);
-      border-radius: var(--radius);
-      box-shadow: var(--shadow-xl);
-      z-index: 900;
-      display: none;
+    /* Agent Monitoring Tile (Always On) */
+    .agent-tile {
+      display: flex;
       flex-direction: column;
       overflow: hidden;
+      max-height: 600px;
     }
-    @media (max-width: 970px) {
-      .agent-panel {
-        width: calc(100vw - 40px);
-        right: 20px;
-        left: 20px;
-        max-height: 60vh;
-      }
-    }
-    .agent-panel-header {
+    .agent-tile-header {
       background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
       color: white;
-      padding: 12px 16px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
+      padding: 12px 16px !important;
       border-bottom: 2px solid var(--accent-hover);
+      margin: -16px -16px 0 -16px;
+    }
+    .agent-tile-header .small {
+      color: rgba(255, 255, 255, 0.9);
     }
     .agent-panel-title {
       font-size: 0.85rem;
@@ -1089,28 +1073,13 @@
       display: flex;
       align-items: center;
       gap: 8px;
-    }
-    .agent-panel-close {
-      background: rgba(255,255,255,0.2);
-      border: none;
       color: white;
-      width: 28px;
-      height: 28px;
-      border-radius: 50%;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 1.2rem;
-      padding: 0;
-    }
-    .agent-panel-close:hover {
-      background: rgba(255,255,255,0.3);
     }
     .agent-panel-content {
       flex: 1;
       overflow-y: auto;
       padding: 16px;
+      min-height: 200px;
     }
     .suggestion-group {
       margin-bottom: 20px;
@@ -2259,12 +2228,41 @@
         </div>
       </div>
 
-      <div class="card">
-        <div class="card-title">
-          Customer summary
-          <span class="small">Show this to customer</span>
+      <!-- Agent Monitoring Tile (Always On) -->
+      <div id="agentSuggestionsPanel" class="card agent-tile">
+        <div class="card-title agent-tile-header">
+          <div class="agent-panel-title">
+            <span>🤖</span>
+            <span>AI Agent</span>
+          </div>
         </div>
-        <p id="customerSummary" class="small">(none)</p>
+
+        <div class="agent-panel-controls">
+          <label class="agent-listen-switch">
+            <input type="checkbox" id="agentListenSwitch">
+            <span class="switch-slider"></span>
+            <span class="switch-label">Listen Mode</span>
+          </label>
+        </div>
+
+        <div class="agent-tabs">
+          <button class="agent-tab active" data-tab="suggestions">Suggestions</button>
+          <button class="agent-tab" data-tab="chat">Chat</button>
+        </div>
+
+        <div id="agentSuggestionsContent" class="agent-panel-content agent-tab-content active" data-content="suggestions">
+          <!-- Content will be dynamically populated by agentMode.js -->
+        </div>
+
+        <div id="agentChatContent" class="agent-panel-content agent-tab-content" data-content="chat">
+          <div id="agentChatMessages" class="agent-chat-messages">
+            <!-- Chat messages will appear here -->
+          </div>
+          <div class="agent-chat-input-wrapper">
+            <textarea id="agentChatInput" class="agent-chat-input" placeholder="Ask the AI agent..."></textarea>
+            <button id="agentChatSend" class="agent-chat-send">Send</button>
+          </div>
+        </div>
       </div>
     </div>
 
@@ -2543,44 +2541,6 @@
   </div>
 
   <!-- jsPDF library for quote PDF generation -->
-  <!-- Agent Monitoring Panel -->
-  <div id="agentSuggestionsPanel" class="agent-panel">
-    <div class="agent-panel-header">
-      <div class="agent-panel-title">
-        <span>🤖</span>
-        <span>AI Agent</span>
-      </div>
-      <button class="agent-panel-close" id="closeAgentPanel">×</button>
-    </div>
-
-    <div class="agent-panel-controls">
-      <label class="agent-listen-switch">
-        <input type="checkbox" id="agentListenSwitch">
-        <span class="switch-slider"></span>
-        <span class="switch-label">Listen Mode</span>
-      </label>
-    </div>
-
-    <div class="agent-tabs">
-      <button class="agent-tab active" data-tab="suggestions">Suggestions</button>
-      <button class="agent-tab" data-tab="chat">Chat</button>
-    </div>
-
-    <div id="agentSuggestionsContent" class="agent-panel-content agent-tab-content active" data-content="suggestions">
-      <!-- Content will be dynamically populated by agentMode.js -->
-    </div>
-
-    <div id="agentChatContent" class="agent-panel-content agent-tab-content" data-content="chat">
-      <div id="agentChatMessages" class="agent-chat-messages">
-        <!-- Chat messages will appear here -->
-      </div>
-      <div class="agent-chat-input-wrapper">
-        <textarea id="agentChatInput" class="agent-chat-input" placeholder="Ask the AI agent..."></textarea>
-        <button id="agentChatSend" class="agent-chat-send">Send</button>
-      </div>
-    </div>
-  </div>
-
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 
   <!-- UI Enhancements -->

--- a/js/agentMode.js
+++ b/js/agentMode.js
@@ -199,19 +199,23 @@ export function analyzeTranscriptForQuestions(sections) {
  * Update the suggestions UI
  */
 function updateSuggestionsUI() {
-  const panel = document.getElementById('agentSuggestionsPanel');
   const content = document.getElementById('agentSuggestionsContent');
 
-  if (!panel || !content) {
+  if (!content) {
     return;
   }
 
+  // Agent tile is always visible, just update content
   if (!AGENT_STATE.enabled) {
-    panel.style.display = 'none';
+    content.innerHTML = `
+      <div style="text-align: center; padding: 20px; color: var(--muted);">
+        <div style="font-size: 2rem; margin-bottom: 8px;">🤖</div>
+        <div style="font-size: 0.85rem;">Agent mode is disabled</div>
+        <div style="font-size: 0.75rem; margin-top: 8px;">Enable agent mode to see suggestions</div>
+      </div>
+    `;
     return;
   }
-
-  panel.style.display = 'flex';
 
   const { critical, important, optional } = AGENT_STATE.suggestions;
   const hasAnySuggestions = critical.length > 0 || important.length > 0 || optional.length > 0;
@@ -295,12 +299,10 @@ function renderQuestion(question, priority) {
 
 /**
  * Clear suggestions UI
+ * Note: Agent tile is always visible, this just updates the content
  */
 function clearSuggestionsUI() {
-  const panel = document.getElementById('agentSuggestionsPanel');
-  if (panel) {
-    panel.style.display = 'none';
-  }
+  updateSuggestionsUI();
 }
 
 /**
@@ -380,17 +382,6 @@ function initAgentUI() {
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         sendChatMessage();
-      }
-    });
-  }
-
-  // Close panel button
-  const closeBtn = document.getElementById('closeAgentPanel');
-  if (closeBtn) {
-    closeBtn.addEventListener('click', () => {
-      const panel = document.getElementById('agentSuggestionsPanel');
-      if (panel) {
-        panel.style.display = 'none';
       }
     });
   }

--- a/js/main.js
+++ b/js/main.js
@@ -1498,8 +1498,10 @@ async function loadChecklistConfigIntoState() {
 // NOTE: Assumes SECTION_SCHEMA has been populated via loadStaticConfig()/ensureSectionSchema().
 // This allows placeholder sections (schema headings) to appear before any worker output arrives.
 function refreshUiFromState() {
-  // 1) Customer summary
-  customerSummaryEl.textContent = lastCustomerSummary || "(none)";
+  // 1) Customer summary (removed from UI, kept for data persistence)
+  if (customerSummaryEl) {
+    customerSummaryEl.textContent = lastCustomerSummary || "(none)";
+  }
 
   // 2) Render sections from the canonical state
   let resolved = Array.isArray(lastSections) ? lastSections : [];


### PR DESCRIPTION
Changes:
- Moved agent panel from fixed popup to static tile position
- Replaced customer summary card with agent monitoring tile
- Removed popup show/hide behavior - agent is now always visible
- Updated CSS to make agent tile fit naturally in card layout
- Removed close button functionality
- Added null check for customerSummaryEl in main.js
- Agent tile displays appropriate messages when disabled

The agent tile is now positioned under the two transcript panels
in the main layout, providing persistent access to AI agent features
without the need for a popup interface.