### PR TITLE
Add DB access and transcription sanity checks

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,7 +13,7 @@ ALLOWED_ORIGIN = "https://YOUR-DOMAIN.example"
 # D1 Database for agent reference materials
 [[d1_databases]]
 binding = "DB"
-database_name = "agent"
+database_name = "agent-db"
 database_id = "87400a56-0eff-4ac0-9bed-3f08ef2e0e79"
 
 # R2 Bucket for reference documents


### PR DESCRIPTION
## Summary
- add D1 query endpoint and point wrangler config at the agent-db database id
- pull latest reference materials with version-aware ordering and feed them into agent and survey prompts
- add transcription sanity checks (pipe sizes and other corrections) across note processing and agent chat contexts

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245d753a64832c93ac28f018c44455)