### PR TITLE
Add auto-generated proposal options and source indicator

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -40,6 +40,7 @@
   </section>
 
   <main id="proposalOutput" class="proposal-output">
+    <p id="optionSourceNote" class="option-source-note" style="display:none; font-size:0.9rem; color:#555; margin-bottom:0.75rem;"></p>
   </main>
 
   <script src="./proposal.js" defer></script>


### PR DESCRIPTION
## Summary
- add a visible note in the proposal output showing where option recommendations come from
- introduce heuristic option generation from survey notes when no System Recommendation JSON is supplied
- flag when real System Recommendation JSON is used and clear prior source notes before new generations

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a68cf5c4832ca9b2eb4990118036)