### PR TITLE
Improve proposal builder data loading

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -33,9 +33,10 @@
     <button id="generateProposalBtn">Generate Proposal</button>
     <button id="printProposalBtn" disabled>Print / Save as PDF</button>
 
+    <p id="autosaveStatus" class="hint" aria-live="polite"></p>
     <p class="hint">
-      For now, select the JSON files manually. In a later version this page can pull the
-      current session data directly from depot-voice-notes and System-recommendation.
+      Select the JSON files manually, or keep Depot Voice Notes open in another tab and we’ll
+      pull your latest autosaved session automatically.
     </p>
   </section>
 


### PR DESCRIPTION
## Summary
- allow the proposal builder to auto-detect the latest Depot Voice Notes session via local storage or the opener window
- support more transcript and notes shapes from exported JSON (full transcripts and section snippets) with clearer load status messaging
- update the proposal builder UI copy to explain autosave loading alongside manual uploads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b0549b00832c993c9bb1866151e7)