### PR TITLE
Delegate proposal tiers to recommendation engine

### DIFF
--- a/js/systemRecommendationShared.js
+++ b/js/systemRecommendationShared.js
@@ -1,9 +1,16 @@
-const SYSTEM_PROFILES = {
+import { generateRecommendations } from './recommendationEngine.js';
+
+const ENGINE_TO_OPTION_KEY = {
+  combi: 'combi',
+  'system-mixergy': 'system_mixergy',
+  'system-unvented': 'system_unvented',
+};
+
+const BASE_OPTION_DEFS = {
   combi: {
-    key: 'combi',
     title: 'High-efficiency combi with smart controls',
     subtitle: 'Space-saving and efficient for smaller homes with good pressure.',
-    strengths: [
+    baseBenefits: [
       'Instant hot water on demand with no separate cylinder.',
       'Saves space and simplifies pipework.',
       'Lower install cost compared to stored hot water systems.',
@@ -12,37 +19,10 @@ const SYSTEM_PROFILES = {
       'Condensing combi boiler, smart controls, magnetic filter, limescale protection, full system cleanse.',
     visualTags: ['combi', 'hive', 'filter', 'flush'],
   },
-  'system-unvented': {
-    key: 'system-unvented',
-    title: 'System boiler with unvented cylinder and smart controls',
-    subtitle: 'Strong hot water performance for multiple bathrooms.',
-    strengths: [
-      'Great flow rates to multiple outlets at once.',
-      'Mains-pressure showers with fast cylinder recovery.',
-      'No loft tanks required, tidy installation.',
-    ],
-    miniSpec:
-      'High-efficiency system boiler, unvented cylinder, smart controls, magnetic filter and full system cleanse.',
-    visualTags: ['system', 'cylinder', 'hive', 'filter', 'flush'],
-  },
-  'regular-openvented': {
-    key: 'regular-openvented',
-    title: 'Regular boiler with vented cylinder',
-    subtitle: 'Best when retaining existing open-vented layout.',
-    strengths: [
-      'Works with low mains pressure and existing tanks.',
-      'Keeps traditional stored hot water arrangement.',
-      'Often simplest swap when replacing like-for-like.',
-    ],
-    miniSpec:
-      'Condensing regular boiler, vented cylinder retained, modern controls, magnetic filter and cleanse.',
-    visualTags: ['regular', 'cylinder', 'filter', 'flush'],
-  },
-  'system-mixergy': {
-    key: 'system-mixergy',
+  system_mixergy: {
     title: 'System boiler with Mixergy smart cylinder',
     subtitle: 'Future-ready hot water with smart, stratified storage.',
-    strengths: [
+    baseBenefits: [
       'Heats only what you need for faster recovery and lower bills.',
       'App monitoring and control with renewable-ready connections.',
       'Great comfort and visibility of stored hot water.',
@@ -51,124 +31,66 @@ const SYSTEM_PROFILES = {
       'System boiler, Mixergy smart cylinder, smart controls, magnetic filter and full system cleanse.',
     visualTags: ['system', 'mixergy', 'hive', 'filter', 'flush'],
   },
+  system_unvented: {
+    title: 'System boiler with unvented cylinder and smart controls',
+    subtitle: 'Strong hot water performance for multiple bathrooms.',
+    baseBenefits: [
+      'Great flow rates to multiple outlets at once.',
+      'Mains-pressure showers with fast cylinder recovery.',
+      'No loft tanks required, tidy installation.',
+    ],
+    miniSpec:
+      'High-efficiency system boiler, unvented cylinder, smart controls, magnetic filter and full system cleanse.',
+    visualTags: ['system', 'cylinder', 'hive', 'filter', 'flush'],
+  },
 };
 
-function baseScore() {
-  return 50;
-}
+const TIER_LABELS = ['GOLD – RECOMMENDED', 'SILVER', 'BRONZE'];
 
-function isHighDemand(input) {
-  const bathrooms = Number(input.bathrooms || 0);
-  const bedrooms = Number(input.bedrooms || 0);
-  return bathrooms >= 2 || bedrooms >= 4 || input.hotWaterDemand === 'high';
-}
+function mapEngineResultToOption(recommendation, tierIdx) {
+  const optionKey = ENGINE_TO_OPTION_KEY[recommendation.key];
+  const base = BASE_OPTION_DEFS[optionKey];
 
-function hasSpaceConstraint(input) {
-  const property = (input.propertyType || '').toLowerCase();
-  return property.includes('flat') || property.includes('apartment') || input.spaceConstraints;
-}
+  if (!base) return null;
 
-function scoreProfile(profileKey, input) {
-  let score = baseScore();
-  const reasons = [];
-  const highDemand = isHighDemand(input);
-  const tightSpace = hasSpaceConstraint(input);
-  const prefersSmart = !!input.wantsSmartControls;
-  const renewableInterest = !!input.consideringRenewables;
-  const currentSystem = (input.currentSystemType || '').toLowerCase();
-
-  if (profileKey === 'combi') {
-    if (highDemand) {
-      score -= 20;
-      reasons.push('Large hot water demand – combi may struggle when several outlets run together.');
-    } else {
-      score += 10;
-      reasons.push('Good fit for light to moderate hot water use.');
-    }
-    if (tightSpace) {
-      score += 20;
-      reasons.push('Saves space by removing the cylinder.');
-    }
+  const benefits = [...base.baseBenefits];
+  if (Array.isArray(recommendation.reasons)) {
+    recommendation.reasons.slice(0, 3).forEach((reason) => benefits.push(reason));
   }
-
-  if (profileKey === 'system-unvented') {
-    if (highDemand) {
-      score += 20;
-      reasons.push('Stored hot water suits multiple bathrooms.');
-    }
-    if (tightSpace) {
-      score -= 10;
-      reasons.push('Needs space for a cylinder.');
-    }
-  }
-
-  if (profileKey === 'regular-openvented') {
-    if (currentSystem.includes('regular') || currentSystem.includes('open vent')) {
-      score += 10;
-      reasons.push('Matches the existing open-vented layout.');
-    }
-    if (tightSpace) {
-      score -= 15;
-      reasons.push('Loft tanks and cylinder take up space.');
-    }
-  }
-
-  if (profileKey === 'system-mixergy') {
-    if (prefersSmart) {
-      score += 12;
-      reasons.push('Smart cylinder pairs well with smart controls.');
-    }
-    if (renewableInterest) {
-      score += 10;
-      reasons.push('Mixergy is ready for future solar or heat pump links.');
-    }
-    if (tightSpace) {
-      score -= 8;
-      reasons.push('Cylinder still required, so allow space.');
-    }
-  }
-
-  if (profileKey !== 'combi' && !highDemand && currentSystem.includes('combi')) {
-    score -= 5;
-    reasons.push('Would introduce stored hot water where demand may not need it.');
-  }
-
-  return { score, reasons };
-}
-
-function rankOptions(input) {
-  const scored = Object.values(SYSTEM_PROFILES).map((profile) => {
-    const { score, reasons } = scoreProfile(profile.key, input);
-    return { profile, score, reasons };
-  });
-  scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, 3);
-}
-
-function buildOption(profile, reasons, tierLabel) {
-  const benefits = [...profile.strengths];
-  reasons.slice(0, 3).forEach((r) => benefits.push(r));
 
   return {
-    title: `${tierLabel}: ${profile.title}`,
-    subtitle: profile.subtitle,
+    title: `${TIER_LABELS[tierIdx] || 'OPTION'}: ${base.title}`,
+    subtitle: base.subtitle,
     benefits: benefits.slice(0, 6),
-    miniSpec: profile.miniSpec,
-    visualTags: profile.visualTags,
+    miniSpec: base.miniSpec,
+    visualTags: base.visualTags,
+    engineScore: recommendation.score,
+    optionKey,
   };
 }
 
-export function getProposalOptions(input = {}) {
-  const shortlist = rankOptions(input);
-  const tiers = ['Gold', 'Silver', 'Bronze'];
+export function rankOptionsWithEngine(requirements = {}, allowedOptionKeys = Object.values(ENGINE_TO_OPTION_KEY)) {
+  const { recommendations = [] } = generateRecommendations(requirements);
+  return recommendations
+    .filter((rec) => allowedOptionKeys.includes(ENGINE_TO_OPTION_KEY[rec.key]))
+    .map((rec) => ({ ...rec, optionKey: ENGINE_TO_OPTION_KEY[rec.key] }))
+    .sort((a, b) => b.score - a.score);
+}
 
-  const [gold, silver, bronze] = shortlist.map((item, idx) =>
-    buildOption(item.profile, item.reasons, tiers[idx] || 'Option')
+export function getProposalOptions(requirements = {}, allowedOptionKeys) {
+  const ranked = rankOptionsWithEngine(
+    requirements,
+    allowedOptionKeys || Object.values(ENGINE_TO_OPTION_KEY)
   );
+
+  const tiered = ranked.slice(0, 3).map((rec, idx) => mapEngineResultToOption(rec, idx)).filter(Boolean);
+
+  const [gold, silver, bronze] = tiered;
 
   return {
     gold,
     silver,
     bronze,
+    ranked,
   };
 }


### PR DESCRIPTION
## Summary
- route proposal Gold/Silver/Bronze options through the System recommendation engine instead of local heuristics
- build engine-ready requirements from stored transcript and notes data when rendering proposals
- keep Mixergy and cylinder option copy aligned while tagging tiers with engine scores

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925be39e248832cad8108d407e403e0)