### PR TITLE
Use live notes to build proposal options dynamically

### DIFF
--- a/proposal.html
+++ b/proposal.html
@@ -36,41 +36,7 @@
           <h2>Your options: Gold, Silver &amp; Bronze</h2>
           <p class="muted">Gold is our recommended fit based on your home and usage.</p>
         </header>
-        <div class="options-grid">
-          <article class="option-card gold">
-            <div class="option-header">
-              <div>
-                <p class="eyebrow">Gold – Recommended</p>
-                <h3 id="gold-title">Loading…</h3>
-                <p id="gold-subtitle" class="muted"></p>
-              </div>
-            </div>
-            <ul id="gold-benefits" class="bullet-list"></ul>
-            <p id="gold-mini-spec" class="mini-spec"></p>
-          </article>
-          <article class="option-card silver">
-            <div class="option-header">
-              <div>
-                <p class="eyebrow">Silver</p>
-                <h3 id="silver-title">Loading…</h3>
-                <p id="silver-subtitle" class="muted"></p>
-              </div>
-            </div>
-            <ul id="silver-benefits" class="bullet-list"></ul>
-            <p id="silver-mini-spec" class="mini-spec"></p>
-          </article>
-          <article class="option-card bronze">
-            <div class="option-header">
-              <div>
-                <p class="eyebrow">Bronze</p>
-                <h3 id="bronze-title">Loading…</h3>
-                <p id="bronze-subtitle" class="muted"></p>
-              </div>
-            </div>
-            <ul id="bronze-benefits" class="bullet-list"></ul>
-            <p id="bronze-mini-spec" class="mini-spec"></p>
-          </article>
-        </div>
+        <div id="options-grid" class="options-grid"></div>
       </section>
 
       <section class="page next-steps">


### PR DESCRIPTION
## Summary
- load proposal data directly from the current app state or saved notes instead of falling back to static placeholders
- normalize sections, notes, and transcript inputs to detect the current system and build "what you told us" from real job data
- generate Gold/Silver/Bronze cards from a dynamic options array (including expert recommendations) and render important notes safely

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c358ca18832cb30ebd129bc933f9)