### PR TITLE
Reinstate send sections panel and sync checklist source

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,14 @@
       position: relative;
       z-index: 2;
     }
+    .results-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin: 0 0 10px;
+      padding: 0 2px;
+      flex-wrap: wrap;
+    }
     .card {
       background: var(--card);
       border-radius: var(--radius);
@@ -2272,6 +2280,9 @@
   </main>
 
   <section class="results-row">
+    <div class="results-actions">
+      <button id="sendSectionsBtn" class="pill-secondary">📨 Send over sections</button>
+    </div>
     <!-- Side-by-side Notes Sections -->
     <div class="notes-grid">
       <div class="card">


### PR DESCRIPTION
## Summary
- add a send-over sections action that opens the slide-over with copy/read controls and auto vs AI note toggle
- keep the slide-over in sync with AI notes updates while allowing copying of the selected note style
- load the checklist from the same structured settings config (sections order + items)

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692796663f68832c891b2fac3d2133e2)