### PR TITLE
Add theme selection and refresh notes styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,17 +4,26 @@
   <meta charset="UTF-8" />
   <title>voice-notes – Live Depot Notes</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <script>
+    (function () {
+      const key = "depot.themePreference";
+      const saved = localStorage.getItem(key);
+      const validThemes = ["blue", "green"];
+      const theme = validThemes.includes(saved) ? saved : "blue";
+      document.documentElement.dataset.theme = theme;
+    })();
+  </script>
   <style>
     :root {
       /* Silver control deck theme */
       --bg: #e7eaef;
       --card: linear-gradient(145deg, #f4f6f8 0%, #dde2e7 50%, #f4f6f8 100%);
       --border: #b5bcc7;
-      --accent: #2f855a;
-      --accent-hover: #276749;
-      --accent-soft: #c9e4d4;
-      --success: #2f855a;
-      --success-soft: #e6f4ec;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --accent-soft: #dbeafe;
+      --success: #2563eb;
+      --success-soft: #e0f2fe;
       --muted: #6b7280;
       --danger: #d14343;
       --warning: #b7791f;
@@ -23,12 +32,21 @@
       --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
       --shadow-lg: 0 10px 18px rgba(0,0,0,0.16);
       --shadow-xl: 0 18px 28px rgba(0,0,0,0.18);
-      --screen-glow: 0 0 12px rgba(79, 209, 197, 0.35);
+      --screen-glow: 0 0 12px rgba(37, 99, 235, 0.35);
       --metal-shine: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.35) 50%, rgba(255,255,255,0) 100%);
       --button-inset: inset 1px 1px 3px rgba(255,255,255,0.65), inset -3px -3px 6px rgba(0,0,0,0.08);
       --screen-bg: linear-gradient(180deg, #eef2f7 0%, #d8dee6 100%);
       --bg-secondary: #dfe3e8;
       --text: #1f2937;
+    }
+
+    :root[data-theme="green"] {
+      --accent: #2f855a;
+      --accent-hover: #276749;
+      --accent-soft: #c9e4d4;
+      --success: #2f855a;
+      --success-soft: #e6f4ec;
+      --screen-glow: 0 0 12px rgba(79, 209, 197, 0.35);
     }
     * { box-sizing: border-box; }
 
@@ -358,14 +376,14 @@
     }
     .sections-list { display: flex; flex-direction: column; gap: 7px; }
     .section-item {
-      background: linear-gradient(145deg, #1f2937 0%, #111827 100%);
+      background: linear-gradient(160deg, #f3f4f6 0%, #e5e7eb 100%);
       border-radius: var(--radius);
       border: 1px solid var(--border);
       padding: 6px 8px 6px;
       position: relative;
       transition: all 0.3s ease;
-      box-shadow: inset 1px 1px 2px rgba(0,0,0,0.4);
-      color: var(--accent);
+      box-shadow: inset 1px 1px 2px rgba(255,255,255,0.35);
+      color: var(--text);
     }
     .section-item::before {
       content: '';
@@ -386,18 +404,19 @@
       pointer-events: none;
     }
     .section-item:hover {
-      background: linear-gradient(145deg, #cbd5e1 0%, #94a3b8 50%, #cbd5e1 100%);
+      background: linear-gradient(160deg, #e5e7eb 0%, #dfe3e8 100%);
       box-shadow:
         var(--shadow-md),
-        0 0 20px rgba(102, 126, 234, 0.2),
+        0 0 20px rgba(37, 99, 235, 0.16),
         inset 0 1px 0 rgba(255,255,255,0.8),
-        inset 0 -1px 0 rgba(0,0,0,0.1);
+        inset 0 -1px 0 rgba(0,0,0,0.05);
       transform: translateX(4px);
-      border-color: #94a3b8;
+      border-color: #cbd5e1;
     }
     .section-item h4 {
       margin: 0 0 3px;
       font-size: .7rem;
+      color: var(--accent);
     }
     .section-item pre {
       margin: 0;

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,23 @@
+const THEME_STORAGE_KEY = "depot.themePreference";
+const VALID_THEMES = ["blue", "green"];
+const DEFAULT_THEME = "blue";
+
+export function getSavedTheme() {
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return VALID_THEMES.includes(stored) ? stored : DEFAULT_THEME;
+}
+
+export function applyTheme(themeName) {
+  const theme = VALID_THEMES.includes(themeName) ? themeName : DEFAULT_THEME;
+  document.documentElement.dataset.theme = theme;
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+  return theme;
+}
+
+export function applyThemeFromStorage() {
+  return applyTheme(getSavedTheme());
+}
+
+export function getThemeOptions() {
+  return [...VALID_THEMES];
+}

--- a/js/themeSettings.js
+++ b/js/themeSettings.js
@@ -1,0 +1,31 @@
+import { applyTheme, applyThemeFromStorage, getThemeOptions } from "./theme.js";
+
+function populateThemeOptions(selectEl) {
+  if (!selectEl) return;
+  const options = getThemeOptions();
+  options.forEach((value) => {
+    if (!selectEl.querySelector(`option[value="${value}"]`)) {
+      const option = document.createElement("option");
+      option.value = value;
+      option.textContent = value.charAt(0).toUpperCase() + value.slice(1);
+      selectEl.appendChild(option);
+    }
+  });
+}
+
+function initThemeSelector() {
+  const select = document.getElementById("colorThemeSelect");
+  if (!select) return;
+  populateThemeOptions(select);
+  const current = applyThemeFromStorage();
+  select.value = current;
+
+  select.addEventListener("change", (event) => {
+    applyTheme(event.target.value);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  applyThemeFromStorage();
+  initThemeSelector();
+});

--- a/settings.html
+++ b/settings.html
@@ -4,21 +4,37 @@
   <meta charset="UTF-8" />
   <title>Survey Brain – Settings</title>
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <script type="module" src="./js/themeSettings.js"></script>
+  <script>
+    (function () {
+      const key = "depot.themePreference";
+      const saved = localStorage.getItem(key);
+      const validThemes = ["blue", "green"];
+      const theme = validThemes.includes(saved) ? saved : "blue";
+      document.documentElement.dataset.theme = theme;
+    })();
+  </script>
   <style>
     :root {
       /* Metal Control Deck Theme */
       --bg: #1a1d24;
       --card: linear-gradient(145deg, #2a2f3a 0%, #363c4a 50%, #2a2f3a 100%);
       --border: #4a5568;
-      --accent: #10b981;
-      --accent-soft: #34d399;
+      --accent: #2563eb;
+      --accent-soft: #dbeafe;
       --muted: #94a3b8;
       --danger: #ef4444;
       --radius: 4px;
-      --screen-glow: 0 0 20px rgba(16, 185, 129, 0.3);
+      --screen-glow: 0 0 20px rgba(37, 99, 235, 0.25);
       --metal-shine: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,0.15) 50%, rgba(255,255,255,0) 100%);
       --button-inset: inset 2px 2px 5px rgba(0,0,0,0.4), inset -2px -2px 5px rgba(255,255,255,0.1);
       --screen-bg: linear-gradient(180deg, #0f1419 0%, #1a1f29 100%);
+    }
+
+    :root[data-theme="green"] {
+      --accent: #10b981;
+      --accent-soft: #34d399;
+      --screen-glow: 0 0 20px rgba(16, 185, 129, 0.3);
     }
     * { box-sizing: border-box; }
 
@@ -513,6 +529,24 @@
         This setting controls the format used when exporting notes, sessions, and automatic/AI notes.
         JSON exports include all data in a structured format, while CSV exports are optimized for spreadsheet applications.
       </p>
+    </section>
+
+    <!-- Colour Theme Preferences -->
+    <section class="card" style="grid-column: 1 / -1;">
+      <div class="card-header">
+        <h2>Colour theme</h2>
+        <span>Pick an accent colour for the app</span>
+      </div>
+
+      <div style="display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
+        <label for="colorThemeSelect" style="font-size: 0.75rem; font-weight: 600; color: var(--muted);">Accent colour</label>
+        <select id="colorThemeSelect" style="padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border); background: var(--card); color: #e2e8f0; box-shadow: var(--button-inset);">
+          <option value="blue">Blue (default)</option>
+          <option value="green">Green</option>
+        </select>
+      </div>
+
+      <p class="hint">Changing the accent colour updates buttons, highlights, and other green elements throughout the app.</p>
     </section>
 
     <!-- AI Instructions Configuration -->


### PR DESCRIPTION
## Summary
- add a persisted colour theme preference with blue as the default and green as an option
- update the settings page to expose the accent colour selector and load it alongside other preferences
- refresh depot notes cards with a softer grey background to match the revised theming

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ca48e508832ca0ec6a86fafa1dca)