### PR TITLE
Add cloud session save feature (Voice Notes 2.0)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2446,6 +2446,15 @@
           <p class="small" style="color: var(--muted); margin-top: 4px;">Session reference followed by type will be used for filenames</p>
         </div>
 
+        <div class="save-section" id="cloudSaveSection" style="border-top: 2px solid var(--border); padding-top: 16px; margin-top: 16px;">
+          <h3>☁️ Cloud Backup (Voice Notes 2.0)</h3>
+          <p class="small" style="color: var(--muted); margin-bottom: 12px;">Save your complete session to the cloud for access across devices</p>
+          <button id="saveToCloudBtn" class="pill-secondary" style="width: 100%;">
+            <span id="cloudSaveBtnText">☁️ Save Session to Cloud</span>
+          </button>
+          <p id="cloudSaveStatus" class="small" style="margin-top: 8px; min-height: 20px;"></p>
+        </div>
+
         <div class="save-actions">
           <button id="cancelSaveMenuBtn" class="pill-secondary">Cancel</button>
           <button id="confirmSaveMenuBtn">Save Selected</button>


### PR DESCRIPTION
- Added "Save to Cloud" button in the save menu modal
- Saves complete session data including transcript, notes, audio, and all metadata
- Requires user authentication via DepotAuth
- Displays upload progress and success/error messages
- Sends session data to /cloud-session endpoint with user credentials
- Shows file size after successful upload
- Gracefully handles errors with user-friendly messages

This feature allows users to backup their survey sessions to the cloud for access across devices and long-term storage.