### PR TITLE
Update JSON import attributes to with syntax

### DIFF
--- a/brain-worker.js
+++ b/brain-worker.js
@@ -1825,8 +1825,8 @@ function normaliseSectionsFromModel(rawSections, schemaInfo) {
 
   return normalised;
 }
-import schemaConfig from "./depot.output.schema.json" assert { type: "json" };
-import checklistConfig from "./checklist.config.json" assert { type: "json" };
+import schemaConfig from "./depot.output.schema.json" with { type: "json" };
+import checklistConfig from "./checklist.config.json" with { type: "json" };
 
 const FUTURE_PLANS_NAME = "Future plans";
 const FUTURE_PLANS_DESCRIPTION = "Notes about any future work or follow-on visits.";

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -1,5 +1,5 @@
-import defaultChecklistConfig from "../../checklist.config.json" assert { type: "json" };
-import defaultDepotSchema from "../../depot.output.schema.json" assert { type: "json" };
+import defaultChecklistConfig from "../../checklist.config.json" with { type: "json" };
+import defaultDepotSchema from "../../depot.output.schema.json" with { type: "json" };
 import {
   DEFAULT_WORKER_ENDPOINT,
   WORKER_ENDPOINT_STORAGE_KEY,

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -2,8 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import worker from '../src/worker.js';
-import depotSchema from '../depot.output.schema.json' assert { type: 'json' };
-import checklistConfig from '../checklist.config.json' assert { type: 'json' };
+import depotSchema from '../depot.output.schema.json' with { type: 'json' };
+import checklistConfig from '../checklist.config.json' with { type: 'json' };
 
 function extractDefaultSections(schema) {
   if (schema && typeof schema === 'object' && Array.isArray(schema.sections)) {


### PR DESCRIPTION
## Summary
- replace deprecated JSON import assertions with the modern `with { type: "json" }` syntax in the worker, shared state, and tests to silence deprecation warnings

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69285bbd46c0832c9ccff2be09291213)