### PR TITLE
revert: use exact System-recommendation scoring without modifications

### DIFF
--- a/src/services/systemRecommendationService.js
+++ b/src/services/systemRecommendationService.js
@@ -163,9 +163,7 @@ export async function buildRecommendationsFromDepotSurvey(requirements) {
       currentBoiler: mapBoilerType(requirements.currentBoilerType),
       currentWater: mapWaterSystem(requirements.currentWaterSystem, requirements.currentBoilerType),
       mainsPressure: waterSupply.pressure,
-      flowRate: waterSupply.flow,
-      wantsSmartTech: requirements.wantsSmartTech || false,
-      consideringRenewables: requirements.consideringRenewables || false
+      flowRate: waterSupply.flow
     };
 
     // Call the recommendation engine


### PR DESCRIPTION
User feedback: 'The logic was all worked out in the other repo'

Removed custom scoring bonuses that were added:
- Smart tech preference (+4 points)
- Renewable readiness (+3 points)
- Pressure utilization (+2 points)

Now uses EXACT logic from https://github.com/martinbibb-cmd/System-recommendation with only the original scoring factors:
- Base performance: +3
- Pressure thresholds: ±2-5
- Like-for-like: +2
- Conversion penalties: -1

This ensures recommendations match the validated algorithm.