### PR TITLE
Guard recommendations when survey data is missing

### DIFF
--- a/js/systemRecommendationUI.js
+++ b/js/systemRecommendationUI.js
@@ -11,6 +11,7 @@ import {
 } from '../src/services/systemRecommendationService.js';
 
 import { extractHeatingRequirements } from './recommendationEngine.js';
+import { hasMeaningfulRequirements } from './systemRecommendationShared.js';
 import { loadChecklistState } from '../src/app/state.js';
 import { buildDepotOutputFromChecklist } from '../src/notes/notesEngine.js';
 
@@ -91,6 +92,12 @@ export async function showSystemRecommendationPanel() {
 
     // Extract requirements from current session
     const requirements = extractHeatingRequirements(sections, notes);
+
+    if (!hasMeaningfulRequirements(requirements)) {
+      closeLoadingModal();
+      renderEmptySystemRecommendations();
+      return;
+    }
 
     // Get recommendations
     const result = await buildRecommendationsFromDepotSurvey(requirements);
@@ -427,6 +434,23 @@ function showLoadingModal(message = 'Generating Recommendations...') {
 function closeLoadingModal() {
   const modal = document.getElementById('system-rec-loading-modal');
   if (modal) modal.remove();
+}
+
+function renderEmptySystemRecommendations() {
+  let container = document.querySelector('#system-recommendations-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'system-recommendations-container';
+    container.style.padding = '20px';
+    document.body.appendChild(container);
+  }
+
+  container.innerHTML = `
+    <div class="no-data-message">
+      <p>We couldn’t find a completed survey for this property.</p>
+      <p>Please finish the voice notes and survey first, then reopen System Recommendations.</p>
+    </div>
+  `;
 }
 
 /**

--- a/proposal.html
+++ b/proposal.html
@@ -71,7 +71,7 @@
         </div>
       </div>
       <div id="options-warning" class="warning" hidden></div>
-      <div class="options-grid">
+      <div class="options-grid" id="proposal-options-container">
         <article class="option-card gold" aria-labelledby="gold-title">
           <div class="option-header">
             <h3 id="gold-title">Gold</h3><span class="badge recommended">Recommended</span>


### PR DESCRIPTION
## Summary
- add a requirements guard to the proposal option generator to avoid engine calls without meaningful survey data
- show friendly messaging in the system recommendations modal and proposal page when no current session or survey data exists
- keep proposal rendering resilient with fallback option mapping for graphics when using guarded options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928ab6cd094832c9b7c54cacdd1140b)