### PR TITLE
Add system recommendation import and proposal builder

### DIFF
--- a/css/proposal.css
+++ b/css/proposal.css
@@ -142,6 +142,81 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
+.proposal-options-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.proposal-option {
+  border: 2px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  background: linear-gradient(180deg, #fff, #f8fafc);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.proposal-option-header {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+
+.proposal-option-label {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.proposal-option-title {
+  margin: 6px 0 4px;
+}
+
+.proposal-option-subtitle {
+  margin: 0;
+  color: var(--muted);
+}
+
+.proposal-option-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  font-size: 14px;
+}
+
+.proposal-option-body h3 {
+  margin: 0 0 6px;
+}
+
+.proposal-option-factors {
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.proposal-option-bestfor {
+  margin: 10px 0 0;
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.no-data-message {
+  background: #f8fafc;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 14px;
+}
+
 .option-card {
   border: 2px solid var(--border);
   border-radius: var(--radius);

--- a/index.html
+++ b/index.html
@@ -168,6 +168,11 @@
       align-items: center;
       margin-left: auto;
     }
+    .toolbar-group {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
     main {
       padding: 0 16px 16px;
       display: grid;
@@ -2163,6 +2168,17 @@
       >
         🎯 System Rec
       </a>
+      <div class="toolbar-group">
+        <button id="btn-import-system-rec" type="button" class="pill-secondary">
+          Import System Recommendation
+        </button>
+        <input
+          id="input-system-rec-file"
+          type="file"
+          accept="application/json"
+          style="display:none"
+        />
+      </div>
       <button id="bugReportBtn" class="pill-secondary">🐛 Report bug</button>
     </div>
   </header>
@@ -2629,6 +2645,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 
   <!-- UI Enhancements -->
+  <script type="module" src="./js/systemRecommendationImport.js"></script>
   <script type="module" src="./js/saveMenu.js"></script>
   <script type="module" src="./js/uiEnhancements.js"></script>
   <script type="module" src="./js/main.js"></script>

--- a/js/systemRecommendationImport.js
+++ b/js/systemRecommendationImport.js
@@ -1,0 +1,57 @@
+const SYSTEM_REC_STORAGE_KEY = 'dvn_system_recommendation';
+
+function storeSystemRecommendationJson(obj) {
+  try {
+    localStorage.setItem(SYSTEM_REC_STORAGE_KEY, JSON.stringify(obj));
+    console.info('[SystemRec] Stored system recommendation JSON', obj);
+    alert('System recommendation imported successfully.');
+  } catch (err) {
+    console.error('[SystemRec] Failed to store system recommendation JSON', err);
+    alert('There was a problem saving the system recommendation data.');
+  }
+}
+
+export function loadSystemRecommendationJson() {
+  try {
+    const raw = localStorage.getItem(SYSTEM_REC_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch (err) {
+    console.error('[SystemRec] Failed to load system recommendation JSON', err);
+    return null;
+  }
+}
+
+function handleSystemRecFileChange(event) {
+  const file = event.target.files?.[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const json = JSON.parse(reader.result);
+      storeSystemRecommendationJson(json);
+    } catch (err) {
+      console.error('[SystemRec] Invalid JSON file', err);
+      alert('That file does not look like valid JSON.');
+    } finally {
+      // Reset input so selecting the same file again still triggers change
+      event.target.value = '';
+    }
+  };
+  reader.readAsText(file);
+}
+
+function initSystemRecImport() {
+  const btn = document.getElementById('btn-import-system-rec');
+  const input = document.getElementById('input-system-rec-file');
+
+  if (!btn || !input) return;
+
+  btn.addEventListener('click', () => input.click());
+  input.addEventListener('change', handleSystemRecFileChange);
+}
+
+document.addEventListener('DOMContentLoaded', initSystemRecImport);
+
+// NOTE: loadSystemRecommendationJson is exported for proposal.js to use.

--- a/proposal.html
+++ b/proposal.html
@@ -67,47 +67,10 @@
         <div>
           <p class="eyebrow">Section 3</p>
           <h2 id="options-title">Your heating &amp; hot water options</h2>
-          <p class="muted">Three clear choices based on our system recommendation engine.</p>
+          <p class="muted">Three clear choices from your imported System Recommendation JSON.</p>
         </div>
       </div>
-      <div id="options-warning" class="warning" hidden></div>
-      <div class="options-grid" id="proposal-options-container">
-        <article class="option-card gold" aria-labelledby="gold-title">
-          <div class="option-header">
-            <h3 id="gold-title">Gold</h3><span class="badge recommended">Recommended</span>
-            <p id="gold-subtitle" class="muted"></p>
-          </div>
-          <div class="option-graphic">
-            <img id="gold-image" alt="System graphic" src="" />
-          </div>
-          <ul id="gold-benefits"></ul>
-          <p id="gold-mini-spec" class="mini-spec"></p>
-        </article>
-
-        <article class="option-card silver" aria-labelledby="silver-title">
-          <div class="option-header">
-            <h3 id="silver-title">Silver</h3>
-            <p id="silver-subtitle" class="muted"></p>
-          </div>
-          <div class="option-graphic">
-            <img id="silver-image" alt="System graphic" src="" />
-          </div>
-          <ul id="silver-benefits"></ul>
-          <p id="silver-mini-spec" class="mini-spec"></p>
-        </article>
-
-        <article class="option-card bronze" aria-labelledby="bronze-title">
-          <div class="option-header">
-            <h3 id="bronze-title">Bronze</h3>
-            <p id="bronze-subtitle" class="muted"></p>
-          </div>
-          <div class="option-graphic">
-            <img id="bronze-image" alt="System graphic" src="" />
-          </div>
-          <ul id="bronze-benefits"></ul>
-          <p id="bronze-mini-spec" class="mini-spec"></p>
-        </article>
-      </div>
+      <div class="proposal-options-grid" id="proposal-options-container"></div>
     </section>
 
     <section class="card" aria-labelledby="next-steps-title">
@@ -143,6 +106,7 @@
     </section>
   </div>
 
+  <script type="module" src="js/systemRecommendationImport.js"></script>
   <script type="module" src="js/proposal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a toolbar import control and shared importer to store System Recommendation JSON locally
- refactor proposal page scripts to read imported recommendation data plus stored transcript details
- refresh proposal layout/styles to render dynamic Gold/Silver/Bronze cards or a helpful no-data message

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bac52a60832cb7f829d9130da037)