### PR TITLE
Fix service worker registration and cloud session auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -2935,53 +2935,37 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
-        // Try to register the service worker
-        const swPath = '/sw.js';
+        // Try to register the service worker (works when hosted in a subdirectory)
+        const swPath = new URL('sw.js', window.location.href).pathname;
 
-        // First check if sw.js exists before registering
-        fetch(swPath, { method: 'HEAD' })
-          .then(response => {
-            if (!response.ok) {
-              console.warn('⚠️ Service Worker file not found at ' + swPath);
-              console.info('ℹ️ Offline mode unavailable. The app will work but won\'t cache for offline use.');
-              console.info('ℹ️ Deploy sw.js at the root of your domain to enable offline support.');
-              return;
-            }
+        navigator.serviceWorker.register(swPath)
+          .then(registration => {
+            console.log('✅ Service Worker registered:', registration.scope);
 
-            // sw.js exists, register it
-            return navigator.serviceWorker.register(swPath)
-              .then(registration => {
-                console.log('✅ Service Worker registered:', registration.scope);
+            // Check for updates periodically
+            setInterval(() => {
+              registration.update();
+            }, 60000); // Check every minute
 
-                // Check for updates periodically
-                setInterval(() => {
-                  registration.update();
-                }, 60000); // Check every minute
-
-                // Listen for updates
-                registration.addEventListener('updatefound', () => {
-                  const newWorker = registration.installing;
-                  if (newWorker) {
-                    newWorker.addEventListener('statechange', () => {
-                      if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                        // New service worker available
-                        console.log('🔄 New version available! Reload to update.');
-                        if (confirm('A new version is available! Reload to update?')) {
-                          newWorker.postMessage({ type: 'SKIP_WAITING' });
-                          window.location.reload();
-                        }
-                      }
-                    });
+            // Listen for updates
+            registration.addEventListener('updatefound', () => {
+              const newWorker = registration.installing;
+              if (newWorker) {
+                newWorker.addEventListener('statechange', () => {
+                  if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                    // New service worker available
+                    console.log('🔄 New version available! Reload to update.');
+                    if (confirm('A new version is available! Reload to update?')) {
+                      newWorker.postMessage({ type: 'SKIP_WAITING' });
+                      window.location.reload();
+                    }
                   }
                 });
-              })
-              .catch(error => {
-                console.error('❌ Service Worker registration failed:', error);
-                console.info('ℹ️ The app will work without offline support.');
-              });
+              }
+            });
           })
           .catch(error => {
-            console.warn('⚠️ Could not check for Service Worker file:', error);
+            console.error(`❌ Service Worker registration failed at ${swPath}:`, error);
             console.info('ℹ️ The app will work without offline support.');
           });
 

--- a/js/saveMenu.js
+++ b/js/saveMenu.js
@@ -753,13 +753,18 @@ async function saveSessionToCloud() {
                       localStorage.getItem('depot-worker-url') ||
                       'https://depot-voice-notes.martinbibb.workers.dev';
     const userInfo = authModule?.getUserInfo();
+    const token = authModule?.getAuthToken ? authModule.getAuthToken() : null;
+
+    if (!token) {
+      throw new Error('Authentication required: missing token');
+    }
 
     // Send to cloud
     const response = await fetch(`${workerUrl}/cloud-session`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${userInfo?.token || ''}`
+        'Authorization': `Bearer ${token}`
       },
       body: JSON.stringify({
         sessionName: session.sessionName,


### PR DESCRIPTION
## Summary
- register the service worker relative to the current path so updates and cache clearing work even when hosted in a subdirectory
- ensure cloud session saves include the user auth token and fail clearly when unauthenticated

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692995254c78832c9d77fa055c1e9ded)