### PR TITLE
Fix broken import in presentationAI.js

### DIFF
--- a/js/presentationAI.js
+++ b/js/presentationAI.js
@@ -4,7 +4,7 @@
  * based on actual conversation and recommendations
  */
 
-import { getWorkerUrl } from './config.js';
+import { loadWorkerEndpoint } from '../src/app/worker-config.js';
 import { generateRecommendations } from './recommendationEngine.js';
 
 // Cache for AI-generated presentations
@@ -47,7 +47,7 @@ export async function generateAIPresentationContent(sessionData, recommendations
   console.log('🤖 Calling AI to generate personalized presentation content...');
 
   try {
-    const workerUrl = getWorkerUrl();
+    const workerUrl = loadWorkerEndpoint();
     const response = await fetch(`${workerUrl}/generate-presentation`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
- Replace non-existent './config.js' import with '../src/app/worker-config.js'
- Use loadWorkerEndpoint() instead of getWorkerUrl()
- Fixes presentation generation functionality

This resolves the import error that was preventing the presentation
feature from working.