### PR TITLE
Optimize photo modal layout for iPad visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -2871,15 +2871,15 @@
         <h2 id="photoModalTitle">Photo Details</h2>
         <button id="closePhotoModalBtn" class="modal-close">Close</button>
       </div>
-      <div style="display: flex; flex-direction: column; gap: 16px; margin-top: 16px; max-height: 70vh; overflow-y: auto;">
+      <div style="display: flex; flex-direction: column; gap: 12px; margin-top: 16px; max-height: 75vh; overflow-y: auto;">
         <!-- Photo display with canvas for annotations -->
         <div style="position: relative; text-align: center; background: #000;">
-          <canvas id="photoCanvas" style="max-width: 100%; max-height: 60vh; cursor: crosshair;"></canvas>
+          <canvas id="photoCanvas" style="max-width: 100%; max-height: 40vh; cursor: crosshair;"></canvas>
         </div>
 
         <!-- Photo metadata -->
-        <div id="photoMetadata" class="card" style="padding: 12px; font-size: 0.85rem;">
-          <div style="display: grid; grid-template-columns: 120px 1fr; gap: 8px;">
+        <div id="photoMetadata" class="card" style="padding: 10px; font-size: 0.85rem;">
+          <div style="display: grid; grid-template-columns: 100px 1fr; gap: 6px; align-items: center;">
             <strong>Section:</strong>
             <select id="photoSectionSelect" style="width: 100%; padding: 4px;">
               <option value="">Not assigned</option>
@@ -2896,18 +2896,18 @@
         </div>
 
         <!-- Annotation tools -->
-        <div class="card" style="padding: 12px;">
-          <div class="card-title" style="font-size: 0.9rem; margin-bottom: 8px;">
+        <div class="card" style="padding: 10px;">
+          <div class="card-title" style="font-size: 0.9rem; margin-bottom: 6px;">
             Markup Tools
           </div>
-          <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+          <div style="display: flex; gap: 6px; flex-wrap: wrap;">
             <button id="addMarkerBtn" class="pill-secondary">📍 Add Marker</button>
             <button id="drawLineBtn" class="pill-secondary">➖ Draw Line</button>
             <button id="drawArrowBtn" class="pill-secondary">➡️ Draw Arrow</button>
             <button id="drawRectBtn" class="pill-secondary">⬜ Draw Rectangle</button>
             <button id="clearAnnotationsBtn" class="pill-secondary">🗑️ Clear Markup</button>
           </div>
-          <div id="markersList" style="margin-top: 12px; font-size: 0.85rem;">
+          <div id="markersList" style="margin-top: 8px; font-size: 0.85rem;">
             <!-- Markers will be listed here -->
           </div>
         </div>


### PR DESCRIPTION
- Reduce canvas max-height from 60vh to 40vh for better tool visibility
- Increase scrollable container from 70vh to 75vh
- Compact spacing throughout modal (gaps, padding reduced by 2-4px)
- Narrow metadata labels from 120px to 100px
- Add vertical alignment to metadata grid

Fixes markup tools being pushed out of visible area on iPad screens.