### PR TITLE
Fix cloud save auth and improve update visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depot-voice-notes",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "dependencies": {
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",

--- a/settings.html
+++ b/settings.html
@@ -480,6 +480,13 @@
     }
   </style>
 
+  <script>
+    window.DepotBuildInfo = {
+      appVersion: '1.1.0',
+      cacheVersion: 'depot-v1.1.0'
+    };
+  </script>
+
   <!-- PWA Manifest -->
   <link rel="manifest" href="/manifest.json">
 
@@ -527,6 +534,52 @@
       </p>
 
       <p class="status" id="syncStatus"></p>
+    </section>
+
+    <!-- Build / Variation info -->
+    <section class="card" style="grid-column: 1 / -1;">
+      <div class="card-header">
+        <h2>Build & Variation Numbers</h2>
+        <span>Identify the exact version currently loaded</span>
+      </div>
+
+      <div class="rows">
+        <div class="row">
+          <span class="order">#1</span>
+          <div>
+            <strong>App variation</strong>
+            <div class="hint">Tracks the main build/version number for this release.</div>
+          </div>
+          <div>
+            <span class="pill" id="appVariationValue">Loading…</span>
+          </div>
+          <div class="row-controls"></div>
+        </div>
+
+        <div class="row">
+          <span class="order">#2</span>
+          <div>
+            <strong>Cache variation</strong>
+            <div class="hint">Matches the service worker cache key to confirm updates shipped.</div>
+          </div>
+          <div>
+            <span class="pill" id="cacheVariationValue">Loading…</span>
+          </div>
+          <div class="row-controls"></div>
+        </div>
+
+        <div class="row">
+          <span class="order">#3</span>
+          <div>
+            <strong>Worker endpoint in use</strong>
+            <div class="hint">Confirms which backend is receiving cloud saves and updates.</div>
+          </div>
+          <div>
+            <span class="pill" id="workerEndpointValue">Loading…</span>
+          </div>
+          <div class="row-controls"></div>
+        </div>
+      </div>
     </section>
 
     <!-- PWA & Updates Section -->
@@ -2089,6 +2142,31 @@ Do not include any explanation outside the JSON.`
       }
     }
 
+    function renderBuildMeta() {
+      const appVariationValue = document.getElementById('appVariationValue');
+      const cacheVariationValue = document.getElementById('cacheVariationValue');
+      const workerEndpointValue = document.getElementById('workerEndpointValue');
+
+      const buildInfo = window.DepotBuildInfo || {};
+      const appVersion = buildInfo.appVersion || '1.1.0';
+      const cacheVersion = buildInfo.cacheVersion || 'depot-v1.1.0';
+      const workerUrl = (window.DepotWorkerConfig?.getWorkerUrl?.())
+        || localStorage.getItem('depot.workerUrl')
+        || localStorage.getItem('depot-worker-url')
+        || 'https://depot-voice-notes.martinbibb.workers.dev';
+
+      if (appVariationValue) {
+        appVariationValue.textContent = appVersion;
+      }
+      if (cacheVariationValue) {
+        cacheVariationValue.textContent = cacheVersion;
+      }
+      if (workerEndpointValue) {
+        workerEndpointValue.textContent = workerUrl.replace(/^https?:\/\//, '');
+        workerEndpointValue.title = workerUrl;
+      }
+    }
+
     // --- Boot ---
     (async function boot() {
       await loadSections();
@@ -2097,6 +2175,7 @@ Do not include any explanation outside the JSON.`
       loadExportFormat();
       renderAIInstructions();
       loadVoiceNotes2Settings();
+      renderBuildMeta();
 
       // Load auth module dynamically
       try {

--- a/src/auth/auth-client.js
+++ b/src/auth/auth-client.js
@@ -427,6 +427,7 @@ if (typeof window !== 'undefined') {
     register,
     login,
     logout,
+    getAuthToken,
     getProfile,
     getUserInfo,
     saveSettingsToCloud,

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
  * Provides offline capability and performance optimization
  */
 
-const CACHE_VERSION = 'depot-v1.0.0';
+const CACHE_VERSION = 'depot-v1.1.0';
 const CACHE_STATIC = `${CACHE_VERSION}-static`;
 const CACHE_DYNAMIC = `${CACHE_VERSION}-dynamic`;
 const CACHE_API = `${CACHE_VERSION}-api`;
@@ -106,6 +106,12 @@ self.addEventListener('fetch', (event) => {
 
   // Skip caching for chrome-extension and other non-http(s) requests
   if (!request.url.startsWith('http')) {
+    return;
+  }
+
+  // Always use network-first for navigation and HTML requests so new versions ship immediately
+  if (request.mode === 'navigate' || request.headers.get('accept')?.includes('text/html')) {
+    event.respondWith(networkFirstStrategy(request, CACHE_STATIC, MAX_DYNAMIC_CACHE_SIZE));
     return;
   }
 


### PR DESCRIPTION
## Summary
- expose the auth token accessor on the global DepotAuth API so cloud saves authenticate correctly
- add build/variation identifiers to the settings page to surface the active app/cache versions and worker endpoint
- bump the service worker cache version and use a network-first strategy for HTML to ship updates reliably

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929c8f45424832c8fc7404e50828d04)