### PR TITLE
Add auto-fill session API and quote builder UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2316,6 +2316,97 @@
       font-size: 0.8rem;
       margin-left: 12px;
     }
+
+    .session-field-list {
+      display: grid;
+      gap: 8px;
+    }
+
+    .session-field-row {
+      display: grid;
+      grid-template-columns: 18px 180px 1fr;
+      gap: 8px;
+      align-items: center;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--bg-secondary);
+    }
+
+    .session-field-label {
+      font-weight: 600;
+      color: var(--text);
+      font-size: 0.9rem;
+    }
+
+    .session-field-value {
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .ai-indicator {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      border: 1px solid var(--border);
+      background: #fff;
+      display: inline-block;
+    }
+
+    .ai-indicator.active {
+      background: #3b82f6;
+      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+      border-color: #1d4ed8;
+    }
+
+    .missing-info-block {
+      margin-top: 12px;
+      padding: 10px;
+      border: 1px dashed var(--border);
+      border-radius: 6px;
+      background: #f8fafc;
+    }
+
+    .missing-info-list {
+      margin: 6px 0 0 16px;
+      padding: 0;
+      color: var(--muted);
+    }
+
+    .missing-info-list li {
+      margin-bottom: 4px;
+      line-height: 1.4;
+    }
+
+    .quote-table-wrapper {
+      overflow-x: auto;
+      margin-top: 8px;
+    }
+
+    .quote-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    .quote-table th,
+    .quote-table td {
+      padding: 6px 8px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+      font-size: 0.9rem;
+    }
+
+    .quote-table th {
+      background: var(--bg-secondary);
+      font-weight: 700;
+    }
+
+    .quote-totals {
+      margin-top: 10px;
+      display: grid;
+      gap: 4px;
+      font-weight: 600;
+    }
   </style>
 
   <!-- PWA Manifest -->
@@ -2549,6 +2640,8 @@
   <section class="results-row">
     <div class="results-actions">
       <button id="sendSectionsBtn" class="pill-secondary">📨 Send over sections</button>
+      <button id="autoFillSessionBtn" class="pill-secondary">✨ Auto-fill from transcript</button>
+      <button id="buildQuoteBtn" class="pill-secondary">💷 Build quote</button>
     </div>
     <!-- Side-by-side Notes Sections -->
     <div class="notes-grid">
@@ -2571,6 +2664,53 @@
           <span class="small">No AI notes yet.</span>
         </div>
       </div>
+    </div>
+
+    <div class="card" id="sessionDataCard">
+      <div class="card-title">
+        Survey session data
+        <span class="small">AI-filled fields highlighted</span>
+      </div>
+      <div id="sessionFieldList" class="session-field-list">
+        <span class="small" style="color: var(--muted);">No session data yet. Capture transcript or auto-fill to populate.</span>
+      </div>
+      <div class="missing-info-block">
+        <div class="card-title" style="font-size: 0.85rem;">
+          Missing info
+          <span class="small">Outstanding follow-ups</span>
+        </div>
+        <ul id="sessionMissingInfo" class="missing-info-list">
+          <li class="small" style="color: var(--muted); list-style: none;">No missing info captured.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="card" id="quoteBuilderCard">
+      <div class="card-title">
+        Quote builder
+        <span class="small">Deterministic pricebook lookup</span>
+      </div>
+      <div id="quoteStatus" class="small" style="color: var(--muted);">No quote built yet.</div>
+      <div id="quoteTokens" class="small" style="margin: 6px 0 10px; color: var(--muted);"></div>
+      <div class="quote-table-wrapper">
+        <table id="quoteLinesTable" class="quote-table" aria-label="Quote lines">
+          <thead>
+            <tr>
+              <th>SKU</th>
+              <th>Description</th>
+              <th>Qty</th>
+              <th>Unit</th>
+              <th>Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td colspan="5" class="small" style="text-align: center; color: var(--muted);">No quote lines yet.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div id="quoteTotals" class="quote-totals"></div>
     </div>
 
     <!-- Photos Section -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "depot-voice-notes",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "dependencies": {
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",

--- a/settings.html
+++ b/settings.html
@@ -482,8 +482,8 @@
 
   <script>
     window.DepotBuildInfo = {
-      appVersion: '1.1.0',
-      cacheVersion: 'depot-v1.1.0'
+      appVersion: '1.2.0',
+      cacheVersion: 'depot-v1.2.0'
     };
   </script>
 
@@ -2148,8 +2148,8 @@ Do not include any explanation outside the JSON.`
       const workerEndpointValue = document.getElementById('workerEndpointValue');
 
       const buildInfo = window.DepotBuildInfo || {};
-      const appVersion = buildInfo.appVersion || '1.1.0';
-      const cacheVersion = buildInfo.cacheVersion || 'depot-v1.1.0';
+      const appVersion = buildInfo.appVersion || '1.2.0';
+      const cacheVersion = buildInfo.cacheVersion || 'depot-v1.2.0';
       const workerUrl = (window.DepotWorkerConfig?.getWorkerUrl?.())
         || localStorage.getItem('depot.workerUrl')
         || localStorage.getItem('depot-worker-url')

--- a/src/api/autoFillSession.js
+++ b/src/api/autoFillSession.js
@@ -1,0 +1,44 @@
+// @ts-check
+import { loadWorkerEndpoint } from "../app/worker-config.js";
+
+const DEFAULT_TOOL = "auto_fill_depot_session";
+
+/**
+ * @typedef {{ path?: string; label?: string; detail?: string; }} MissingInfoItem
+ * @typedef {{ sessionPatch: Partial<import("../models/depotSession.js").DepotSurveySession>, missingInfo: MissingInfoItem[] }} AutoFillResponse
+ */
+
+/**
+ * Call the AI worker to auto-fill a Depot survey session from transcript + current session.
+ * @param {string} transcript
+ * @param {import("../models/depotSession.js").DepotSurveySession} session
+ * @returns {Promise<AutoFillResponse>}
+ */
+export async function autoFillSession(transcript, session) {
+  const workerUrl = loadWorkerEndpoint();
+  const payload = {
+    transcript,
+    session,
+    tool: DEFAULT_TOOL,
+    schema: "DepotSurveySession"
+  };
+
+  const response = await fetch(`${workerUrl}/tools/auto-fill-session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Auto-fill request failed: ${response.status} ${response.statusText} – ${text}`);
+  }
+
+  const data = await response.json();
+  return {
+    sessionPatch: data?.sessionPatch || {},
+    missingInfo: Array.isArray(data?.missingInfo) ? data.missingInfo : []
+  };
+}
+
+export default autoFillSession;

--- a/src/api/autoFillSession.ts
+++ b/src/api/autoFillSession.ts
@@ -1,0 +1,47 @@
+import { loadWorkerEndpoint } from "../app/worker-config.js";
+import type { DepotSurveySession } from "../models/depotSession.js";
+
+export interface MissingInfoItem {
+  path?: string;
+  label?: string;
+  detail?: string;
+}
+
+export interface AutoFillResponse {
+  sessionPatch: Partial<DepotSurveySession>;
+  missingInfo: MissingInfoItem[];
+}
+
+const DEFAULT_TOOL = "auto_fill_depot_session";
+
+export async function autoFillSession(
+  transcript: string,
+  session: DepotSurveySession
+): Promise<AutoFillResponse> {
+  const workerUrl = loadWorkerEndpoint();
+  const payload = {
+    transcript,
+    session,
+    tool: DEFAULT_TOOL,
+    schema: "DepotSurveySession"
+  };
+
+  const response = await fetch(`${workerUrl}/tools/auto-fill-session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Auto-fill request failed: ${response.status} ${response.statusText} – ${text}`);
+  }
+
+  const data = (await response.json()) as Partial<AutoFillResponse>;
+  return {
+    sessionPatch: data.sessionPatch || {},
+    missingInfo: Array.isArray(data.missingInfo) ? data.missingInfo : []
+  };
+}
+
+export default autoFillSession;

--- a/src/models/depotSession.ts
+++ b/src/models/depotSession.ts
@@ -4,6 +4,25 @@ export type SystemType = "combi" | "system" | "regular" | "back_boiler" | "unkno
 export type JobType = "swap" | "conversion" | "new_install" | "unknown";
 export type HomecareStatus = "active" | "lapsed" | "none" | "unknown";
 export type FuelType = "gas" | "lpg" | "oil" | "electric" | "unknown";
+export interface MissingInfoItem {
+  path?: string;
+  label?: string;
+  detail?: string;
+}
+export interface QuoteLine {
+  sku: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  category: string;
+}
+export interface QuoteResult {
+  lines: QuoteLine[];
+  grossPriceIncVat: number;
+  totalDiscountIncVat: number;
+  totalPricePayableIncVat: number;
+}
 
 export interface DepotSurveySessionMeta {
   sessionName?: string;
@@ -26,6 +45,7 @@ export interface VulnerabilityInfo {
 
 export interface ExistingSystemInfo {
   systemType?: SystemType;
+  existingSystemType?: string;
   jobType?: JobType;
   boilerLocation?: string;
   controls?: string;
@@ -75,6 +95,7 @@ export interface BoilerJobType {
   boilerLocation?: string;
   flueType?: string;
   controls?: string;
+  systemTypeA?: string;
   notes?: string;
 }
 
@@ -82,6 +103,7 @@ export interface CleansingAndProtection {
   cleansingRequired?: YesNoNone;
   inhibitorRequired?: YesNoNone;
   magneticFilter?: YesNoNone;
+  magneticFilterType?: string;
   notes?: string;
 }
 
@@ -170,7 +192,7 @@ export interface DepotSurveySession {
   materials?: MaterialItem[];
   ai?: AINotes;
   sections?: any[];
-  missingInfo?: string[];
+  missingInfo?: Array<string | MissingInfoItem>;
   fullTranscript?: string;
   photos?: any[];
   checkedItems?: any;
@@ -180,6 +202,7 @@ export interface DepotSurveySession {
   distances?: any;
   audioBase64?: string;
   audioMime?: string;
+  quote?: QuoteResult;
 }
 
 export default DepotSurveySession;

--- a/src/quote/quoteEngine.js
+++ b/src/quote/quoteEngine.js
@@ -1,0 +1,99 @@
+// @ts-check
+import { loadWorkerEndpoint } from "../app/worker-config.js";
+
+/**
+ * @typedef {{ sku: string; description: string; quantity: number; unitPrice: number; totalPrice: number; category: string; }} QuoteLine
+ * @typedef {{ lines: QuoteLine[]; grossPriceIncVat: number; totalDiscountIncVat: number; totalPricePayableIncVat: number; }} QuoteResult
+ */
+
+function normaliseNumber(value) {
+  const num = typeof value === "string" ? Number(value) : value;
+  return Number.isFinite(num) ? Number(num) : undefined;
+}
+
+/**
+ * Derive deterministic pricebook tokens from a Depot survey session.
+ * @param {import("../models/depotSession.js").DepotSurveySession} session
+ * @returns {string[]}
+ */
+export function deriveTokensFromSession(session) {
+  const tokens = [];
+  const existingType = session.existingSystem?.existingSystemType || session.existingSystem?.systemType;
+  const systemTypeA = session.boilerJob?.systemTypeA;
+
+  if (existingType === "conventional" && typeof systemTypeA === "string" && systemTypeA.startsWith("A2")) {
+    tokens.push("LABOUR_A2_CONV_CONV");
+  }
+
+  const totalHeatLoss = normaliseNumber(session.heatLoss?.totalHeatLossKw);
+  const fuelType = session.existingSystem?.fuelType;
+  if (typeof totalHeatLoss === "number" && totalHeatLoss <= 18 && fuelType === "natural_gas") {
+    tokens.push("BOILER_REGULAR_15KW_WORC_RI");
+  }
+
+  const magneticFilterType = session.cleansing?.magneticFilterType;
+  if (magneticFilterType && magneticFilterType.toLowerCase().includes("22mm")) {
+    tokens.push("MAG_FILTER_22MM");
+  }
+
+  if (session.cleansing?.cleansingRequired === "yes") {
+    tokens.push("CLEANSING_POWERFLUSH");
+  }
+
+  if (session.allowances?.charges && session.allowances.charges.some((c) => c.label?.toLowerCase().includes("asbestos"))) {
+    tokens.push("ASBESTOS_CHARGE");
+  }
+
+  return tokens;
+}
+
+/**
+ * Build a quote by fetching SKU and price data for the derived tokens.
+ * @param {string[]} tokens
+ * @returns {Promise<QuoteResult>}
+ */
+export async function buildQuoteFromTokens(tokens) {
+  const workerUrl = loadWorkerEndpoint();
+  const response = await fetch(`${workerUrl}/pricebook/quote`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tokens })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Quote build failed: ${response.status} ${response.statusText} – ${text}`);
+  }
+
+  const data = await response.json();
+  const lines = Array.isArray(data?.lines)
+    ? data.lines.map((line) => {
+        const qty = normaliseNumber(line.quantity) ?? 1;
+        const unit = normaliseNumber(line.unitPrice) ?? 0;
+        return {
+          sku: line.sku || "",
+          description: line.description || "",
+          quantity: qty,
+          unitPrice: unit,
+          totalPrice: normaliseNumber(line.totalPrice) ?? qty * unit,
+          category: line.category || "General"
+        };
+      })
+    : [];
+
+  const grossPriceIncVat = normaliseNumber(data?.grossPriceIncVat) ?? lines.reduce((sum, l) => sum + l.totalPrice, 0);
+  const totalDiscountIncVat = normaliseNumber(data?.totalDiscountIncVat) ?? 0;
+  const totalPricePayableIncVat = normaliseNumber(data?.totalPricePayableIncVat) ?? grossPriceIncVat - totalDiscountIncVat;
+
+  return {
+    lines,
+    grossPriceIncVat,
+    totalDiscountIncVat,
+    totalPricePayableIncVat
+  };
+}
+
+export default {
+  deriveTokensFromSession,
+  buildQuoteFromTokens
+};

--- a/src/quote/quoteEngine.ts
+++ b/src/quote/quoteEngine.ts
@@ -1,0 +1,100 @@
+import { loadWorkerEndpoint } from "../app/worker-config.js";
+import type { DepotSurveySession } from "../models/depotSession.js";
+
+export interface QuoteLine {
+  sku: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  category: string;
+}
+
+export interface QuoteResult {
+  lines: QuoteLine[];
+  grossPriceIncVat: number;
+  totalDiscountIncVat: number;
+  totalPricePayableIncVat: number;
+}
+
+function normaliseNumber(value?: unknown): number | undefined {
+  const num = typeof value === "string" ? Number(value) : (value as number | undefined);
+  return Number.isFinite(num) ? Number(num) : undefined;
+}
+
+export function deriveTokensFromSession(session: DepotSurveySession): string[] {
+  const tokens: string[] = [];
+  const existingType = session.existingSystem?.existingSystemType || session.existingSystem?.systemType;
+  const systemTypeA = (session.boilerJob as any)?.systemTypeA as string | undefined;
+
+  if (existingType === "conventional" && typeof systemTypeA === "string" && systemTypeA.startsWith("A2")) {
+    tokens.push("LABOUR_A2_CONV_CONV");
+  }
+
+  const totalHeatLoss = normaliseNumber(session.heatLoss?.totalHeatLossKw);
+  const fuelType = session.existingSystem?.fuelType;
+  if (typeof totalHeatLoss === "number" && totalHeatLoss <= 18 && fuelType === "natural_gas") {
+    tokens.push("BOILER_REGULAR_15KW_WORC_RI");
+  }
+
+  const magneticFilterType = (session.cleansing as any)?.magneticFilterType as string | undefined;
+  if (magneticFilterType && magneticFilterType.toLowerCase().includes("22mm")) {
+    tokens.push("MAG_FILTER_22MM");
+  }
+
+  if (session.cleansing?.cleansingRequired === "yes") {
+    tokens.push("CLEANSING_POWERFLUSH");
+  }
+
+  if (session.allowances?.charges && session.allowances.charges.some((c) => c.label?.toLowerCase().includes("asbestos"))) {
+    tokens.push("ASBESTOS_CHARGE");
+  }
+
+  return tokens;
+}
+
+export async function buildQuoteFromTokens(tokens: string[]): Promise<QuoteResult> {
+  const workerUrl = loadWorkerEndpoint();
+  const response = await fetch(`${workerUrl}/pricebook/quote`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ tokens })
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Quote build failed: ${response.status} ${response.statusText} – ${text}`);
+  }
+
+  const data = (await response.json()) as Partial<QuoteResult> & { lines?: Partial<QuoteLine>[] };
+  const lines: QuoteLine[] = Array.isArray(data.lines)
+    ? data.lines.map((line) => {
+        const qty = normaliseNumber(line.quantity) ?? 1;
+        const unit = normaliseNumber(line.unitPrice) ?? 0;
+        return {
+          sku: line.sku || "",
+          description: line.description || "",
+          quantity: qty,
+          unitPrice: unit,
+          totalPrice: normaliseNumber(line.totalPrice) ?? qty * unit,
+          category: line.category || "General"
+        };
+      })
+    : [];
+
+  const grossPriceIncVat = normaliseNumber(data.grossPriceIncVat) ?? lines.reduce((sum, l) => sum + l.totalPrice, 0);
+  const totalDiscountIncVat = normaliseNumber(data.totalDiscountIncVat) ?? 0;
+  const totalPricePayableIncVat = normaliseNumber(data.totalPricePayableIncVat) ?? grossPriceIncVat - totalDiscountIncVat;
+
+  return {
+    lines,
+    grossPriceIncVat,
+    totalDiscountIncVat,
+    totalPricePayableIncVat
+  };
+}
+
+export default {
+  deriveTokensFromSession,
+  buildQuoteFromTokens
+};

--- a/src/state/sessionStore.js
+++ b/src/state/sessionStore.js
@@ -21,7 +21,8 @@ export function createEmptyDepotSurveySession() {
     ai: {},
     sections: [],
     missingInfo: [],
-    photos: []
+    photos: [],
+    quote: undefined
   };
 }
 

--- a/src/state/sessionStore.ts
+++ b/src/state/sessionStore.ts
@@ -23,7 +23,8 @@ export function createEmptyDepotSurveySession(): DepotSurveySession {
     ai: {},
     sections: [],
     missingInfo: [],
-    photos: []
+    photos: [],
+    quote: undefined
   };
 }
 

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
  * Provides offline capability and performance optimization
  */
 
-const CACHE_VERSION = 'depot-v1.1.0';
+const CACHE_VERSION = 'depot-v1.2.0';
 const CACHE_STATIC = `${CACHE_VERSION}-static`;
 const CACHE_DYNAMIC = `${CACHE_VERSION}-dynamic`;
 const CACHE_API = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
## Summary
- add an autoFillSession helper that posts transcript+session data to the worker and returns missing info
- surface auto-fill and pricebook quote builder controls with session highlighting in the main UI
- derive quote tokens deterministically, call the pricebook endpoint, and bump build/version metadata

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ef7ed52c832c8703ae5c0677c23b)