### PR TITLE
Update service worker cache version to 1.2.1

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
  * Provides offline capability and performance optimization
  */
 
-const CACHE_VERSION = 'depot-v1.2.0';
+const CACHE_VERSION = 'depot-v1.2.1';
 const CACHE_STATIC = `${CACHE_VERSION}-static`;
 const CACHE_DYNAMIC = `${CACHE_VERSION}-dynamic`;
 const CACHE_API = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
Bump CACHE_VERSION from 'depot-v1.2.0' to 'depot-v1.2.1' to match package.json version. This ensures the service worker detects the update and invalidates old caches, allowing users to pull down the latest version with the photo markup fixes.

When the cache version changes:
- Old caches (depot-v1.2.0-*) will be deleted on activation
- New caches (depot-v1.2.1-*) will be created
- Users will receive the updated files including the fixed photo markup tools with touch support