### PR TITLE
Implement automatic PWA updates with zero user interaction (v1.3.1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3104,6 +3104,12 @@
           .then(registration => {
             console.log('✅ Service Worker registered:', registration.scope);
 
+            // Auto-reload when new service worker takes control (no user interaction needed)
+            navigator.serviceWorker.addEventListener('controllerchange', () => {
+              console.log('🔄 New service worker activated - reloading...');
+              window.location.reload();
+            });
+
             // Check for updates periodically
             setInterval(() => {
               registration.update();
@@ -3115,12 +3121,10 @@
               if (newWorker) {
                 newWorker.addEventListener('statechange', () => {
                   if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-                    // New service worker available
-                    console.log('🔄 New version available! Reload to update.');
-                    if (confirm('A new version is available! Reload to update?')) {
-                      newWorker.postMessage({ type: 'SKIP_WAITING' });
-                      window.location.reload();
-                    }
+                    // New service worker available - activate immediately
+                    console.log('🔄 New version available! Activating automatically...');
+                    newWorker.postMessage({ type: 'SKIP_WAITING' });
+                    // controllerchange listener will handle the reload
                   }
                 });
               }

--- a/login.html
+++ b/login.html
@@ -654,6 +654,12 @@
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
+        // Auto-reload when new service worker takes control (no user interaction needed)
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          console.log('🔄 New service worker activated - reloading...');
+          window.location.reload();
+        });
+
         navigator.serviceWorker.register('/sw.js')
           .then(registration => {
             console.log('✅ Service Worker registered:', registration.scope);

--- a/settings.html
+++ b/settings.html
@@ -2206,6 +2206,12 @@ Do not include any explanation outside the JSON.`
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {
+        // Auto-reload when new service worker takes control (no user interaction needed)
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          console.log('🔄 New service worker activated - reloading...');
+          window.location.reload();
+        });
+
         navigator.serviceWorker.register('/sw.js')
           .then(registration => {
             console.log('✅ Service Worker registered:', registration.scope);

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
  * Provides offline capability and performance optimization
  */
 
-const CACHE_VERSION = 'depot-v1.3.0';
+const CACHE_VERSION = 'depot-v1.3.1';
 const CACHE_STATIC = `${CACHE_VERSION}-static`;
 const CACHE_DYNAMIC = `${CACHE_VERSION}-dynamic`;
 const CACHE_API = `${CACHE_VERSION}-api`;


### PR DESCRIPTION
Problem: Users had to manually clear cache or confirm update dialogs to get new versions. iOS Safari's frozen tabs meant service workers never updated, leaving users stuck on old versions indefinitely.

Solution: Added `controllerchange` listener that automatically reloads the page when a new service worker activates. Combined with existing `skipWaiting()` and `clients.claim()`, this creates a seamless auto-update flow.

Changes:
- Added controllerchange listener to index.html, login.html, and settings.html
- Removed confirm dialog from index.html update flow
- Bumped service worker cache version to v1.3.1 to trigger update
- Users now always get the latest version, even with tabs left open for days

This matches the update strategy used by Twitter PWA, Notion PWA, and VSCode.dev.