### PR TITLE
Fix: Update displayed app version to 1.3.2

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -482,8 +482,8 @@
 
   <script>
     window.DepotBuildInfo = {
-      appVersion: '1.2.0',
-      cacheVersion: 'depot-v1.2.0'
+      appVersion: '1.3.2',
+      cacheVersion: 'depot-v1.3.2'
     };
   </script>
 
@@ -2151,8 +2151,8 @@ Do not include any explanation outside the JSON.`
       const workerEndpointValue = document.getElementById('workerEndpointValue');
 
       const buildInfo = window.DepotBuildInfo || {};
-      const appVersion = buildInfo.appVersion || '1.2.0';
-      const cacheVersion = buildInfo.cacheVersion || 'depot-v1.2.0';
+      const appVersion = buildInfo.appVersion || '1.3.2';
+      const cacheVersion = buildInfo.cacheVersion || 'depot-v1.3.2';
       const workerUrl = (window.DepotWorkerConfig?.getWorkerUrl?.())
         || localStorage.getItem('depot.workerUrl')
         || localStorage.getItem('depot-worker-url')


### PR DESCRIPTION
The DepotBuildInfo object in settings.html was still showing 1.2.0, which is why users weren't seeing the new version after updates.

This updates both the main build info object and fallback values.